### PR TITLE
Update sbt, plugins, dependencies and Scala versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
-target/
+*~
 .DS_Store
 .ensime
-.lib
-.ensime_lucene
 .ensime_cache
-*~
+.ensime_lucene
+.idea
+.lib
+target/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,14 @@
 language: scala
 scala:
-  - 2.11.7
+  - 2.11.12
+  - 2.12.10
+  - 2.13.0
+jdk:
+  - openjdk8
 cache:
   directories:
     - $HOME/.ivy2/cache
-    - $HOME/.sbt/boot/
+    - $HOME/.sbt
 script:
   - sbt clean coverage test
 after_success:

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,5 @@
+import sbt.CrossVersion
+import sbt.Keys.scalaVersion
 import scalariform.formatter.preferences._
 
 name := "phalange"
@@ -6,19 +8,48 @@ organization := "net.jcazevedo"
 
 version := "0.1-SNAPSHOT"
 
-scalaVersion := "2.11.7"
+scalaVersion := "2.13.0"
+
+crossScalaVersions := Seq("2.11.12", "2.12.10", "2.13.0")
 
 libraryDependencies ++= Seq(
-  "org.specs2"             %% "specs2-core"   % "3.6.5"  % "test")
+  "org.specs2" %% "specs2-core" % "4.8.0" % "test")
 
-scalacOptions ++= Seq(
-  "-deprecation",
-  "-unchecked",
-  "-feature",
-  "-language:implicitConversions",
-  "-Ywarn-unused-import")
+scalacOptions ++= {
+  val allVersionFlags = List(
+    "-encoding", "UTF-8", // yes, this is 2 args
+    "-feature",
+    "-unchecked",
+    "-Ywarn-dead-code",
+    "-Ywarn-numeric-widen")
 
-scalacOptions in (Compile, console) ~= (_ filterNot (_ == "-Ywarn-unused-import"))
+  CrossVersion.partialVersion(scalaVersion.value) match {
+    case Some((2, 11)) =>
+      allVersionFlags ++ List(
+        "-deprecation",
+        "-Xlint",
+        "-Xfatal-warnings",
+        "-Yno-adapted-args",
+        "-Ywarn-unused-import")
+
+    case Some((2, 12)) =>
+      allVersionFlags ++ List(
+        "-deprecation",
+        "-Xlint:_,-unused",
+        "-Xfatal-warnings",
+        "-Yno-adapted-args",
+        "-Ywarn-unused:_,-implicits")
+
+    case Some((2, 13)) =>
+      allVersionFlags ++ List(
+        "-Ywarn-unused:_,-implicits")
+
+    case _ =>
+      allVersionFlags
+  }
+}
+
+scalacOptions in (Compile, console) --= Seq("-Xfatal-warnings", "-Ywarn-unused-import", "-Ywarn-unused:_,-implicits")
 scalacOptions in (Test, console) := (scalacOptions in (Compile, console)).value
 
 scalariformPreferences := scalariformPreferences.value

--- a/build.sbt
+++ b/build.sbt
@@ -21,20 +21,17 @@ scalacOptions ++= Seq(
 scalacOptions in (Compile, console) ~= (_ filterNot (_ == "-Ywarn-unused-import"))
 scalacOptions in (Test, console) := (scalacOptions in (Compile, console)).value
 
-scalariformSettings
-
-ScalariformKeys.preferences := ScalariformKeys.preferences.value
-  .setPreference(AlignParameters, true)
-  .setPreference(DoubleIndentClassDeclaration, true)
+scalariformPreferences := scalariformPreferences.value
+  .setPreference(DanglingCloseParenthesis, Prevent)
+  .setPreference(DoubleIndentConstructorArguments, true)
+  .setPreference(SpacesAroundMultiImports, true)
 
 publishMavenStyle := true
 
-publishTo <<= version { v =>
+publishTo := {
   val nexus = "https://oss.sonatype.org/"
-  if (v.trim.endsWith("SNAPSHOT"))
-    Some("snapshots" at nexus + "content/repositories/snapshots")
-  else
-    Some("releases"  at nexus + "service/local/staging/deploy/maven2")
+  if (isSnapshot.value) Some("snapshots" at nexus + "content/repositories/snapshots")
+  else Some("releases" at nexus + "service/local/staging/deploy/maven2")
 }
 
 publishArtifact in Test := false

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.3.3

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,3 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.3.0")
-
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.0.4")
-
-addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.0.0")
+addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.3")
+addSbtPlugin("org.scoverage"   % "sbt-coveralls"   % "1.2.7")
+addSbtPlugin("org.scoverage"   % "sbt-scoverage"   % "1.6.0")

--- a/src/main/scala/net/jcazevedo/phalange/FingerTree.scala
+++ b/src/main/scala/net/jcazevedo/phalange/FingerTree.scala
@@ -1,5 +1,7 @@
 package net.jcazevedo.phalange
 
+import scala.language.implicitConversions
+
 trait FingerTree[+A] {
   def foldRight[B >: A, C](z: C)(f: (B, C) => C): C
   def foldLeft[B >: A, C](z: C)(f: (C, B) => C): C
@@ -65,8 +67,8 @@ case class Single[+A](x: A) extends FingerTree[A] {
       case s: Single[_] => (ts.foldLeft[FingerTree[B]](this))(_ + _) + s.x
       case _ => x :: (ts foldRight (xs))(_ :: _)
     }
-  def viewL = Some(x, Empty)
-  def viewR = Some(Empty, x)
+  def viewL = Some((x, Empty))
+  def viewR = Some((Empty, x))
 }
 
 class Deep[+A](val pr: Digit[A], val m: Lazy[FingerTree[Node[A]]], val sf: Digit[A])

--- a/src/main/scala/net/jcazevedo/phalange/FingerTree.scala
+++ b/src/main/scala/net/jcazevedo/phalange/FingerTree.scala
@@ -70,7 +70,7 @@ case class Single[+A](x: A) extends FingerTree[A] {
 }
 
 class Deep[+A](val pr: Digit[A], val m: Lazy[FingerTree[Node[A]]], val sf: Digit[A])
-    extends FingerTree[A] {
+  extends FingerTree[A] {
   def foldRight[B >: A, C](z: C)(f: (B, C) => C): C = {
     def f1(d: Digit[B], b: C) = (d foldRight (b))(f(_, _))
     def f2(t: FingerTree[Node[B]], b: C): C =

--- a/src/test/scala/net/jcazevedo/phalange/FingerTreeSpec.scala
+++ b/src/test/scala/net/jcazevedo/phalange/FingerTreeSpec.scala
@@ -11,16 +11,12 @@ class FingerTreeSpec extends Specification {
           Deep(
             Digit(
               Node('i', 's'),
-              Node('i', 's')
-            ),
+              Node('i', 's')),
             Empty,
             Digit(
               Node('n', 'o', 't'),
-              Node('a', 't')
-            )
-          ),
-          Digit('r', 'e', 'e')
-        )
+              Node('a', 't'))),
+          Digit('r', 'e', 'e'))
 
       val l = f.foldRight(List[Char]()) { (c, l) =>
         c :: l
@@ -36,16 +32,12 @@ class FingerTreeSpec extends Specification {
           Deep(
             Digit(
               Node('i', 's'),
-              Node('i', 's')
-            ),
+              Node('i', 's')),
             Empty,
             Digit(
               Node('n', 'o', 't'),
-              Node('a', 't')
-            )
-          ),
-          Digit('r', 'e', 'e')
-        )
+              Node('a', 't'))),
+          Digit('r', 'e', 'e'))
 
       val l = f.foldLeft(List[Char]()) { (l, c) =>
         l ++ List(c)


### PR DESCRIPTION
This PR updates sbt, sbt plugins, specs2 and starts cross compiling for Scala 2.11, 2.12 and 2.13.