### PR TITLE
Update sbt to 1.7.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -49,8 +49,8 @@ scalacOptions ++= {
   }
 }
 
-scalacOptions in (Compile, console) --= Seq("-Xfatal-warnings", "-Ywarn-unused-import", "-Ywarn-unused:_,-implicits")
-scalacOptions in (Test, console) := (scalacOptions in (Compile, console)).value
+Compile / console / scalacOptions --= Seq("-Xfatal-warnings", "-Ywarn-unused-import", "-Ywarn-unused:_,-implicits")
+Test / console / scalacOptions := (Compile / console / scalacOptions).value
 
 scalariformPreferences := scalariformPreferences.value
   .setPreference(DanglingCloseParenthesis, Prevent)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.3
+sbt.version=1.7.2


### PR DESCRIPTION
Updates sbt to 1.7.2 and fixes deprecated `in` syntax.