### PR TITLE
Add initial support for annotated sequences

### DIFF
--- a/src/main/scala/net/jcazevedo/phalange/Digit.scala
+++ b/src/main/scala/net/jcazevedo/phalange/Digit.scala
@@ -1,18 +1,88 @@
 package net.jcazevedo.phalange
 
-private[phalange] sealed trait Digit[+A] extends Iterable[A] {
-  def iterator: Iterator[A] =
-    this match {
-      case Digit.One(a)           => Iterator(a)
-      case Digit.Two(a, b)        => Iterator(a, b)
-      case Digit.Three(a, b, c)   => Iterator(a, b, c)
-      case Digit.Four(a, b, c, d) => Iterator(a, b, c, d)
-    }
+private[phalange] sealed abstract class Digit[V, +A] extends Iterable[A] {
+  private[phalange] def fold[B](
+      one: (Lazy[V], A) => B,
+      two: (Lazy[V], A, A) => B,
+      three: (Lazy[V], A, A, A) => B,
+      four: (Lazy[V], A, A, A, A) => B
+  ): B
+
+  final def measure: V =
+    fold(
+      one = (lm, _) => lm.value,
+      two = (lm, _, _) => lm.value,
+      three = (lm, _, _, _) => lm.value,
+      four = (lm, _, _, _, _) => lm.value
+    )
+
+  final def iterator: Iterator[A] =
+    fold(
+      one = (_, a) => Iterator(a),
+      two = (_, a, b) => Iterator(a, b),
+      three = (_, a, b, c) => Iterator(a, b, c),
+      (_, a, b, c, d) => Iterator(a, b, c, d)
+    )
 }
 
 private[phalange] object Digit {
-  private[phalange] case class One[A](a: A) extends Digit[A]
-  private[phalange] case class Two[A](a: A, b: A) extends Digit[A]
-  private[phalange] case class Three[A](a: A, b: A, c: A) extends Digit[A]
-  private[phalange] case class Four[A](a: A, b: A, c: A, d: A) extends Digit[A]
+  private[phalange] def apply[V, A](a: A)(implicit measured: Measured[A, V]): Digit[V, A] =
+    new Digit[V, A] {
+      def fold[B](
+          one: (Lazy[V], A) => B,
+          two: (Lazy[V], A, A) => B,
+          three: (Lazy[V], A, A, A) => B,
+          four: (Lazy[V], A, A, A, A) => B
+      ): B =
+        one(new Lazy(measured.apply(a)), a)
+    }
+
+  private[phalange] def apply[V, A](a: A, b: A)(implicit measured: Measured[A, V]): Digit[V, A] =
+    new Digit[V, A] {
+      def fold[B](
+          one: (Lazy[V], A) => B,
+          two: (Lazy[V], A, A) => B,
+          three: (Lazy[V], A, A, A) => B,
+          four: (Lazy[V], A, A, A, A) => B
+      ): B =
+        two(new Lazy(measured.append(measured.apply(a), measured.apply(b))), a, b)
+    }
+
+  private[phalange] def apply[V, A](a: A, b: A, c: A)(implicit measured: Measured[A, V]): Digit[V, A] =
+    new Digit[V, A] {
+      def fold[B](
+          one: (Lazy[V], A) => B,
+          two: (Lazy[V], A, A) => B,
+          three: (Lazy[V], A, A, A) => B,
+          four: (Lazy[V], A, A, A, A) => B
+      ): B =
+        three(
+          new Lazy(measured.append(measured.apply(a), measured.append(measured.apply(b), measured.apply(c)))),
+          a,
+          b,
+          c
+        )
+    }
+
+  private[phalange] def apply[V, A](a: A, b: A, c: A, d: A)(implicit measured: Measured[A, V]): Digit[V, A] =
+    new Digit[V, A] {
+      def fold[B](
+          one: (Lazy[V], A) => B,
+          two: (Lazy[V], A, A) => B,
+          three: (Lazy[V], A, A, A) => B,
+          four: (Lazy[V], A, A, A, A) => B
+      ): B =
+        four(
+          new Lazy(
+            measured.append(
+              measured.apply(a),
+              measured.append(measured.apply(b), measured.append(measured.apply(c), measured.apply(d)))
+            )
+          ),
+          a,
+          b,
+          c,
+          d
+        )
+    }
 }

--- a/src/main/scala/net/jcazevedo/phalange/Digit.scala
+++ b/src/main/scala/net/jcazevedo/phalange/Digit.scala
@@ -1,6 +1,6 @@
 package net.jcazevedo.phalange
 
-private[phalange] sealed abstract class Digit[V, +A] extends Iterable[A] {
+private[phalange] sealed abstract class Digit[V, A] extends Iterable[A] {
   private[phalange] def fold[B](
       one: (Lazy[V], A) => B,
       two: (Lazy[V], A, A) => B,

--- a/src/main/scala/net/jcazevedo/phalange/FingerTree.scala
+++ b/src/main/scala/net/jcazevedo/phalange/FingerTree.scala
@@ -231,11 +231,7 @@ object FingerTree {
       ): B =
         deep(
           new Lazy(
-            measured.append(
-              measured
-                .append(Measured.measure[Digit[A], V](pr), Measured.measure[FingerTree[V, Node[V, A]], V](m.value)),
-              Measured.measure[Digit[A], V](sf)
-            )
+            measured.append(measured.append(Measured.measure(pr), Measured.measure(m.value)), Measured.measure(sf))
           ),
           pr,
           m,

--- a/src/main/scala/net/jcazevedo/phalange/FingerTree.scala
+++ b/src/main/scala/net/jcazevedo/phalange/FingerTree.scala
@@ -219,7 +219,7 @@ object FingerTree {
 
   private[phalange] def deep[V, A](pr: Digit[A], m: Lazy[FingerTree[V, Node[V, A]]], sf: Digit[A])(implicit measured: Measured[A, V]): FingerTree[V, A] =
     FingerTree.Deep(
-      new Lazy(measured.append(measured.append(Measured.measure(pr), Measured.measure(m.value)), Measured.measure(sf))),
+      new Lazy(measured.append(measured.append(Measured.measure[Digit[A], V](pr), Measured.measure[FingerTree[V, Node[V, A]], V](m.value)), Measured.measure[Digit[A], V](sf))),
       pr,
       m,
       sf

--- a/src/main/scala/net/jcazevedo/phalange/FingerTree.scala
+++ b/src/main/scala/net/jcazevedo/phalange/FingerTree.scala
@@ -9,6 +9,9 @@ sealed abstract class FingerTree[V, A](implicit measured: Measured[A, V]) {
       deep: (Lazy[V], Digit[A], Lazy[FingerTree[V, Node[V, A]]], Digit[A]) => B
   ): B
 
+  def measure: V =
+    fold(empty = measured.empty, single = a => measured.apply(a), deep = (lm, _, _, _) => lm.value)
+
   def foldRight[B](z: B)(op: (A, B) => B): B =
     fold(
       empty = z,
@@ -230,9 +233,7 @@ object FingerTree {
           deep: (Lazy[V], Digit[A], Lazy[FingerTree[V, Node[V, A]]], Digit[A]) => B
       ): B =
         deep(
-          new Lazy(
-            measured.append(measured.append(Measured.measure(pr), Measured.measure(m.value)), Measured.measure(sf))
-          ),
+          new Lazy(measured.append(Measured.measure(pr), measured.append(m.value.measure, Measured.measure(sf)))),
           pr,
           m,
           sf

--- a/src/main/scala/net/jcazevedo/phalange/FingerTree.scala
+++ b/src/main/scala/net/jcazevedo/phalange/FingerTree.scala
@@ -27,7 +27,7 @@ sealed trait FingerTree[V, +A] {
         sf.foldLeft(m.value.foldLeft(pr.foldLeft(z)(op))((b, a) => a.foldLeft(b)(op)))(op)
     }
 
-  def +:[B >: A](a: B)(implicit measured: Measured[B, V], monoid: Monoid[V]): FingerTree[V, B] =
+  def +:[B >: A](a: B)(implicit measured: Measured[B, V]): FingerTree[V, B] =
     this match {
       case FingerTree.Empty() =>
         FingerTree.Single(a)
@@ -48,7 +48,7 @@ sealed trait FingerTree[V, +A] {
         FingerTree.deep(Digit.Two(a, b), new Lazy(Node.node3(c, d, e) +: m.value), sf)
     }
 
-  def :+[B >: A](a: B)(implicit measured: Measured[B, V], monoid: Monoid[V]): FingerTree[V, B] =
+  def :+[B >: A](a: B)(implicit measured: Measured[B, V]): FingerTree[V, B] =
     this match {
       case FingerTree.Empty() =>
         FingerTree.Single(a)
@@ -69,10 +69,10 @@ sealed trait FingerTree[V, +A] {
         FingerTree.deep(pr, new Lazy(m.value :+ Node.node3(e, d, c)), Digit.Two(b, a))
     }
 
-  def ++[B >: A](that: FingerTree[V, B])(implicit measured: Measured[B, V], monoid: Monoid[V]): FingerTree[V, B] =
+  def ++[B >: A](that: FingerTree[V, B])(implicit measured: Measured[B, V]): FingerTree[V, B] =
     FingerTree.app3(this, List.empty, that)
 
-  private def viewL(implicit measured: Measured[A, V], monoid: Monoid[V]): ViewL[V, A] =
+  private def viewL(implicit measured: Measured[A, V]): ViewL[V, A] =
     this match {
       case FingerTree.Empty() =>
         ViewL.Empty()
@@ -105,49 +105,49 @@ sealed trait FingerTree[V, +A] {
         ViewL.Cons(a, new Lazy(FingerTree.deep(Digit.Three(b, c, d), m, sf)))
     }
 
-  def lazyListL(implicit measured: Measured[A, V], monoid: Monoid[V]): LazyList[A] =
+  def lazyListL(implicit measured: Measured[A, V]): LazyList[A] =
     LazyList.unfold(this)(_.viewL match {
       case ViewL.Cons(head, tail) => Some((head, tail.value))
       case ViewL.Empty()          => None
     })
 
-  def toList(implicit measured: Measured[A, V], monoid: Monoid[V]): List[A] =
+  def toList(implicit measured: Measured[A, V]): List[A] =
     lazyListL.toList
 
-  def isEmpty(implicit measured: Measured[A, V], monoid: Monoid[V]): Boolean =
+  def isEmpty(implicit measured: Measured[A, V]): Boolean =
     viewL match {
       case ViewL.Cons(_, _) => false
       case ViewL.Empty()    => true
     }
 
-  def nonEmpty(implicit measured: Measured[A, V], monoid: Monoid[V]): Boolean =
+  def nonEmpty(implicit measured: Measured[A, V]): Boolean =
     !isEmpty
 
-  def headL(implicit measured: Measured[A, V], monoid: Monoid[V]): A =
+  def headL(implicit measured: Measured[A, V]): A =
     viewL match {
       case ViewL.Cons(a, _) => a
       case ViewL.Empty()    => throw new NoSuchElementException("head of empty finger tree")
     }
 
-  def tailL(implicit measured: Measured[A, V], monoid: Monoid[V]): FingerTree[V, A] =
+  def tailL(implicit measured: Measured[A, V]): FingerTree[V, A] =
     viewL match {
       case ViewL.Cons(_, rest) => rest.value
       case ViewL.Empty()       => throw new NoSuchElementException("tail of empty finger tree")
     }
 
-  def headLOption(implicit measured: Measured[A, V], monoid: Monoid[V]): Option[A] =
+  def headLOption(implicit measured: Measured[A, V]): Option[A] =
     viewL match {
       case ViewL.Cons(a, _) => Some(a)
       case ViewL.Empty()    => None
     }
 
-  def tailLOption(implicit measured: Measured[A, V], monoid: Monoid[V]): Option[FingerTree[V, A]] =
+  def tailLOption(implicit measured: Measured[A, V]): Option[FingerTree[V, A]] =
     viewL match {
       case ViewL.Cons(_, rest) => Some(rest.value)
       case ViewL.Empty()       => None
     }
 
-  private def viewR(implicit measured: Measured[A, V], monoid: Monoid[V]): ViewR[V, A] =
+  private def viewR(implicit measured: Measured[A, V]): ViewR[V, A] =
     this match {
       case FingerTree.Empty() =>
         ViewR.Empty()
@@ -180,31 +180,31 @@ sealed trait FingerTree[V, +A] {
         ViewR.Cons(new Lazy(FingerTree.deep(pr, m, Digit.Three(d, c, b))), a)
     }
 
-  def lazyListR(implicit measured: Measured[A, V], monoid: Monoid[V]): LazyList[A] =
+  def lazyListR(implicit measured: Measured[A, V]): LazyList[A] =
     LazyList.unfold(this)(_.viewR match {
       case ViewR.Cons(tail, head) => Some((head, tail.value))
       case ViewR.Empty()          => None
     })
 
-  def headR(implicit measured: Measured[A, V], monoid: Monoid[V]): A =
+  def headR(implicit measured: Measured[A, V]): A =
     viewR match {
       case ViewR.Cons(_, a) => a
       case ViewR.Empty()    => throw new NoSuchElementException("head of empty finger tree")
     }
 
-  def tailR(implicit measured: Measured[A, V], monoid: Monoid[V]): FingerTree[V, A] =
+  def tailR(implicit measured: Measured[A, V]): FingerTree[V, A] =
     viewR match {
       case ViewR.Cons(rest, _) => rest.value
       case ViewR.Empty()       => throw new NoSuchElementException("tail of empty finger tree")
     }
 
-  def headROption(implicit measured: Measured[A, V], monoid: Monoid[V]): Option[A] =
+  def headROption(implicit measured: Measured[A, V]): Option[A] =
     viewR match {
       case ViewR.Cons(_, a) => Some(a)
       case ViewR.Empty()    => None
     }
 
-  def tailROption(implicit measured: Measured[A, V], monoid: Monoid[V]): Option[FingerTree[V, A]] =
+  def tailROption(implicit measured: Measured[A, V]): Option[FingerTree[V, A]] =
     viewR match {
       case ViewR.Cons(rest, _) => Some(rest.value)
       case ViewR.Empty()       => None
@@ -217,21 +217,15 @@ object FingerTree {
   private[phalange] case class Deep[V, A](v: Lazy[V], pr: Digit[A], m: Lazy[FingerTree[V, Node[V, A]]], sf: Digit[A])
       extends FingerTree[V, A]
 
-  private[phalange] def deep[V, A](pr: Digit[A], m: Lazy[FingerTree[V, Node[V, A]]], sf: Digit[A])(implicit
-      measured: Measured[A, V],
-      monoid: Monoid[V]
-  ): FingerTree[V, A] =
+  private[phalange] def deep[V, A](pr: Digit[A], m: Lazy[FingerTree[V, Node[V, A]]], sf: Digit[A])(implicit measured: Measured[A, V]): FingerTree[V, A] =
     FingerTree.Deep(
-      new Lazy(monoid.append(monoid.append(Measured.measure(pr), Measured.measure(m.value)), Measured.measure(sf))),
+      new Lazy(measured.append(measured.append(Measured.measure(pr), Measured.measure(m.value)), Measured.measure(sf))),
       pr,
       m,
       sf
     )
 
-  private[phalange] def nodes[V, A](a: A, b: A, rest: A*)(implicit
-      measured: Measured[A, V],
-      monoid: Monoid[V]
-  ): List[Node[V, A]] =
+  private[phalange] def nodes[V, A](a: A, b: A, rest: A*)(implicit measured: Measured[A, V]): List[Node[V, A]] =
     if (rest.isEmpty)
       List(Node.node2(a, b))
     else if (rest.length == 1)
@@ -241,10 +235,7 @@ object FingerTree {
     else
       Node.node3(a, b, rest.head) :: nodes(rest.tail.head, rest.tail.tail.head, rest.tail.tail.tail: _*)
 
-  private[phalange] def app3[V, A](a: FingerTree[V, A], b: List[A], c: FingerTree[V, A])(implicit
-      measured: Measured[A, V],
-      monoid: Monoid[V]
-  ): FingerTree[V, A] =
+  private[phalange] def app3[V, A](a: FingerTree[V, A], b: List[A], c: FingerTree[V, A])(implicit measured: Measured[A, V]): FingerTree[V, A] =
     (a, b, c) match {
       case (FingerTree.Empty(), ts, xs) =>
         ts.foldRight(xs)(_ +: _)
@@ -286,6 +277,6 @@ object FingerTree {
   def empty[V, A]: FingerTree[V, A] =
     Empty()
 
-  def apply[V, A](as: A*)(implicit measured: Measured[A, V], monoid: Monoid[V]): FingerTree[V, A] =
+  def apply[V, A](as: A*)(implicit measured: Measured[A, V]): FingerTree[V, A] =
     as.foldRight(FingerTree.empty[V, A])(_ +: _)
 }

--- a/src/main/scala/net/jcazevedo/phalange/FingerTree.scala
+++ b/src/main/scala/net/jcazevedo/phalange/FingerTree.scala
@@ -202,13 +202,21 @@ sealed abstract class FingerTree[V, A](implicit measured: Measured[A, V]) {
 object FingerTree {
   private[phalange] def empty[V, A](implicit measured: Measured[A, V]): FingerTree[V, A] =
     new FingerTree[V, A] {
-      def fold[B](empty: => B, single: A => B,deep: (Lazy[V], Digit[A], Lazy[FingerTree[V, Node[V, A]]], Digit[A]) => B): B =
+      def fold[B](
+          empty: => B,
+          single: A => B,
+          deep: (Lazy[V], Digit[A], Lazy[FingerTree[V, Node[V, A]]], Digit[A]) => B
+      ): B =
         empty
     }
 
   private[phalange] def single[V, A](a: A)(implicit measured: Measured[A, V]): FingerTree[V, A] =
     new FingerTree[V, A] {
-      def fold[B](empty: => B, single: A => B,deep: (Lazy[V], Digit[A], Lazy[FingerTree[V, Node[V, A]]], Digit[A]) => B): B =
+      def fold[B](
+          empty: => B,
+          single: A => B,
+          deep: (Lazy[V], Digit[A], Lazy[FingerTree[V, Node[V, A]]], Digit[A]) => B
+      ): B =
         single(a)
     }
 
@@ -216,7 +224,11 @@ object FingerTree {
       measured: Measured[A, V]
   ): FingerTree[V, A] =
     new FingerTree[V, A] {
-      def fold[B](empty: => B,single: A => B,deep: (Lazy[V], Digit[A], Lazy[FingerTree[V, Node[V, A]]], Digit[A]) => B): B =
+      def fold[B](
+          empty: => B,
+          single: A => B,
+          deep: (Lazy[V], Digit[A], Lazy[FingerTree[V, Node[V, A]]], Digit[A]) => B
+      ): B =
         deep(
           new Lazy(
             measured.append(measured.append(Measured.measure(pr), Measured.measure(m.value)), Measured.measure(sf))

--- a/src/main/scala/net/jcazevedo/phalange/FingerTree.scala
+++ b/src/main/scala/net/jcazevedo/phalange/FingerTree.scala
@@ -2,209 +2,197 @@ package net.jcazevedo.phalange
 
 import scala.collection.compat.immutable.LazyList
 
-sealed trait FingerTree[V, +A] {
+sealed abstract class FingerTree[V, A](implicit measured: Measured[A, V]) {
+  protected[phalange] def fold[B](
+      empty: => B,
+      single: A => B,
+      deep: (Lazy[V], Digit[A], Lazy[FingerTree[V, Node[V, A]]], Digit[A]) => B
+  ): B
+
   def foldRight[B](z: B)(op: (A, B) => B): B =
-    this match {
-      case FingerTree.Empty() =>
-        z
-
-      case FingerTree.Single(x) =>
-        op(x, z)
-
-      case FingerTree.Deep(_, pr, m, sf) =>
-        pr.foldRight(m.value.foldRight(sf.foldRight(z)(op))((a, b) => a.foldRight(b)(op)))(op)
-    }
+    fold(
+      empty = z,
+      single = op(_, z),
+      deep = (_, pr, m, sf) => pr.foldRight(m.value.foldRight(sf.foldRight(z)(op))((a, b) => a.foldRight(b)(op)))(op)
+    )
 
   def foldLeft[B](z: B)(op: (B, A) => B): B =
-    this match {
-      case FingerTree.Empty() =>
-        z
+    fold(
+      empty = z,
+      single = op(z, _),
+      deep = (_, pr, m, sf) => sf.foldLeft(m.value.foldLeft(pr.foldLeft(z)(op))((b, a) => a.foldLeft(b)(op)))(op)
+    )
 
-      case FingerTree.Single(x) =>
-        op(z, x)
+  def +:(a: A): FingerTree[V, A] =
+    fold(
+      empty = FingerTree.single(a),
+      single = b => FingerTree.deep(Digit.One(a), new Lazy(FingerTree.empty), Digit.One(b)),
+      deep = {
+        case (_, Digit.One(b), m, sf) =>
+          FingerTree.deep(Digit.Two(a, b), m, sf)
 
-      case FingerTree.Deep(_, pr, m, sf) =>
-        sf.foldLeft(m.value.foldLeft(pr.foldLeft(z)(op))((b, a) => a.foldLeft(b)(op)))(op)
-    }
+        case (_, Digit.Two(b, c), m, sf) =>
+          FingerTree.deep(Digit.Three(a, b, c), m, sf)
 
-  def +:[B >: A](a: B)(implicit measured: Measured[B, V]): FingerTree[V, B] =
-    this match {
-      case FingerTree.Empty() =>
-        FingerTree.Single(a)
+        case (_, Digit.Three(b, c, d), m, sf) =>
+          FingerTree.deep(Digit.Four(a, b, c, d), m, sf)
 
-      case FingerTree.Single(b) =>
-        FingerTree.deep(Digit.One(a), new Lazy(FingerTree.Empty()), Digit.One(b))
+        case (_, Digit.Four(b, c, d, e), m, sf) =>
+          FingerTree.deep(Digit.Two(a, b), new Lazy(Node.node3(c, d, e) +: m.value), sf)
+      }
+    )
 
-      case FingerTree.Deep(_, Digit.One(b), m, sf) =>
-        FingerTree.deep(Digit.Two(a, b), m, sf)
+  def :+(a: A): FingerTree[V, A] =
+    fold(
+      empty = FingerTree.single(a),
+      single = b => FingerTree.deep(Digit.One(b), new Lazy(FingerTree.empty), Digit.One(a)),
+      deep = {
+        case (_, pr, m, Digit.One(b)) =>
+          FingerTree.deep(pr, m, Digit.Two(b, a))
 
-      case FingerTree.Deep(_, Digit.Two(b, c), m, sf) =>
-        FingerTree.deep(Digit.Three(a, b, c), m, sf)
+        case (_, pr, m, Digit.Two(c, b)) =>
+          FingerTree.deep(pr, m, Digit.Three(c, b, a))
 
-      case FingerTree.Deep(_, Digit.Three(b, c, d), m, sf) =>
-        FingerTree.deep(Digit.Four(a, b, c, d), m, sf)
+        case (_, pr, m, Digit.Three(d, c, b)) =>
+          FingerTree.deep(pr, m, Digit.Four(d, c, b, a))
 
-      case FingerTree.Deep(_, Digit.Four(b, c, d, e), m, sf) =>
-        FingerTree.deep(Digit.Two(a, b), new Lazy(Node.node3(c, d, e) +: m.value), sf)
-    }
+        case (_, pr, m, Digit.Four(e, d, c, b)) =>
+          FingerTree.deep(pr, new Lazy(m.value :+ Node.node3(e, d, c)), Digit.Two(b, a))
+      }
+    )
 
-  def :+[B >: A](a: B)(implicit measured: Measured[B, V]): FingerTree[V, B] =
-    this match {
-      case FingerTree.Empty() =>
-        FingerTree.Single(a)
-
-      case FingerTree.Single(b) =>
-        FingerTree.deep(Digit.One(b), new Lazy(FingerTree.Empty()), Digit.One(a))
-
-      case FingerTree.Deep(_, pr, m, Digit.One(b)) =>
-        FingerTree.deep(pr, m, Digit.Two(b, a))
-
-      case FingerTree.Deep(_, pr, m, Digit.Two(c, b)) =>
-        FingerTree.deep(pr, m, Digit.Three(c, b, a))
-
-      case FingerTree.Deep(_, pr, m, Digit.Three(d, c, b)) =>
-        FingerTree.deep(pr, m, Digit.Four(d, c, b, a))
-
-      case FingerTree.Deep(_, pr, m, Digit.Four(e, d, c, b)) =>
-        FingerTree.deep(pr, new Lazy(m.value :+ Node.node3(e, d, c)), Digit.Two(b, a))
-    }
-
-  def ++[B >: A](that: FingerTree[V, B])(implicit measured: Measured[B, V]): FingerTree[V, B] =
+  def ++(that: FingerTree[V, A]): FingerTree[V, A] =
     FingerTree.app3(this, List.empty, that)
 
-  private def viewL(implicit measured: Measured[A, V]): ViewL[V, A] =
-    this match {
-      case FingerTree.Empty() =>
-        ViewL.Empty()
+  private def viewL: ViewL[V, A] =
+    fold(
+      empty = ViewL.Empty(),
+      single = a => ViewL.Cons(a, new Lazy(FingerTree.empty)),
+      deep = {
+        case (_, Digit.One(a), m, sf) =>
+          ViewL.Cons(
+            a,
+            new Lazy(m.value.viewL match {
+              case ViewL.Empty() =>
+                FingerTree.measured(sf.toSeq: _*)
 
-      case FingerTree.Single(a) =>
-        ViewL.Cons(a, new Lazy(FingerTree.empty))
+              case ViewL.Cons(Node.Node2(_, a, b), rest) =>
+                FingerTree.deep(Digit.Two(a, b), rest, sf)
 
-      case FingerTree.Deep(_, Digit.One(a), m, sf) =>
-        ViewL.Cons(
-          a,
-          new Lazy(m.value.viewL match {
-            case ViewL.Empty() =>
-              FingerTree.apply(sf.toSeq: _*)
+              case ViewL.Cons(Node.Node3(_, a, b, c), rest) =>
+                FingerTree.deep(Digit.Three(a, b, c), rest, sf)
+            })
+          )
 
-            case ViewL.Cons(Node.Node2(_, a, b), rest) =>
-              FingerTree.deep(Digit.Two(a, b), rest, sf)
+        case (_, Digit.Two(a, b), m, sf) =>
+          ViewL.Cons(a, new Lazy(FingerTree.deep(Digit.One(b), m, sf)))
 
-            case ViewL.Cons(Node.Node3(_, a, b, c), rest) =>
-              FingerTree.deep(Digit.Three(a, b, c), rest, sf)
-          })
-        )
+        case (_, Digit.Three(a, b, c), m, sf) =>
+          ViewL.Cons(a, new Lazy(FingerTree.deep(Digit.Two(b, c), m, sf)))
 
-      case FingerTree.Deep(_, Digit.Two(a, b), m, sf) =>
-        ViewL.Cons(a, new Lazy(FingerTree.deep(Digit.One(b), m, sf)))
+        case (_, Digit.Four(a, b, c, d), m, sf) =>
+          ViewL.Cons(a, new Lazy(FingerTree.deep(Digit.Three(b, c, d), m, sf)))
+      }
+    )
 
-      case FingerTree.Deep(_, Digit.Three(a, b, c), m, sf) =>
-        ViewL.Cons(a, new Lazy(FingerTree.deep(Digit.Two(b, c), m, sf)))
-
-      case FingerTree.Deep(_, Digit.Four(a, b, c, d), m, sf) =>
-        ViewL.Cons(a, new Lazy(FingerTree.deep(Digit.Three(b, c, d), m, sf)))
-    }
-
-  def lazyListL(implicit measured: Measured[A, V]): LazyList[A] =
+  def lazyListL: LazyList[A] =
     LazyList.unfold(this)(_.viewL match {
       case ViewL.Cons(head, tail) => Some((head, tail.value))
       case ViewL.Empty()          => None
     })
 
-  def toList(implicit measured: Measured[A, V]): List[A] =
+  def toList: List[A] =
     lazyListL.toList
 
-  def isEmpty(implicit measured: Measured[A, V]): Boolean =
+  def isEmpty: Boolean =
     viewL match {
       case ViewL.Cons(_, _) => false
       case ViewL.Empty()    => true
     }
 
-  def nonEmpty(implicit measured: Measured[A, V]): Boolean =
+  def nonEmpty: Boolean =
     !isEmpty
 
-  def headL(implicit measured: Measured[A, V]): A =
+  def headL: A =
     viewL match {
       case ViewL.Cons(a, _) => a
       case ViewL.Empty()    => throw new NoSuchElementException("head of empty finger tree")
     }
 
-  def tailL(implicit measured: Measured[A, V]): FingerTree[V, A] =
+  def tailL: FingerTree[V, A] =
     viewL match {
       case ViewL.Cons(_, rest) => rest.value
       case ViewL.Empty()       => throw new NoSuchElementException("tail of empty finger tree")
     }
 
-  def headLOption(implicit measured: Measured[A, V]): Option[A] =
+  def headLOption: Option[A] =
     viewL match {
       case ViewL.Cons(a, _) => Some(a)
       case ViewL.Empty()    => None
     }
 
-  def tailLOption(implicit measured: Measured[A, V]): Option[FingerTree[V, A]] =
+  def tailLOption: Option[FingerTree[V, A]] =
     viewL match {
       case ViewL.Cons(_, rest) => Some(rest.value)
       case ViewL.Empty()       => None
     }
 
-  private def viewR(implicit measured: Measured[A, V]): ViewR[V, A] =
-    this match {
-      case FingerTree.Empty() =>
-        ViewR.Empty()
+  private def viewR: ViewR[V, A] =
+    fold(
+      empty = ViewR.Empty(),
+      single = a => ViewR.Cons(new Lazy(FingerTree.empty), a),
+      deep = {
+        case (_, pr, m, Digit.One(a)) =>
+          ViewR.Cons(
+            new Lazy(m.value.viewR match {
+              case ViewR.Empty() =>
+                FingerTree.measured(pr.toSeq: _*)
 
-      case FingerTree.Single(a) =>
-        ViewR.Cons(new Lazy(FingerTree.empty), a)
+              case ViewR.Cons(rest, Node.Node2(_, b, a)) =>
+                FingerTree.deep(pr, rest, Digit.Two(b, a))
 
-      case FingerTree.Deep(_, pr, m, Digit.One(a)) =>
-        ViewR.Cons(
-          new Lazy(m.value.viewR match {
-            case ViewR.Empty() =>
-              FingerTree.apply(pr.toSeq: _*)
+              case ViewR.Cons(rest, Node.Node3(_, c, b, a)) =>
+                FingerTree.deep(pr, rest, Digit.Three(c, b, a))
+            }),
+            a
+          )
 
-            case ViewR.Cons(rest, Node.Node2(_, b, a)) =>
-              FingerTree.deep(pr, rest, Digit.Two(b, a))
+        case (_, pr, m, Digit.Two(b, a)) =>
+          ViewR.Cons(new Lazy(FingerTree.deep(pr, m, Digit.One(b))), a)
 
-            case ViewR.Cons(rest, Node.Node3(_, c, b, a)) =>
-              FingerTree.deep(pr, rest, Digit.Three(c, b, a))
-          }),
-          a
-        )
+        case (_, pr, m, Digit.Three(c, b, a)) =>
+          ViewR.Cons(new Lazy(FingerTree.deep(pr, m, Digit.Two(c, b))), a)
 
-      case FingerTree.Deep(_, pr, m, Digit.Two(b, a)) =>
-        ViewR.Cons(new Lazy(FingerTree.deep(pr, m, Digit.One(b))), a)
+        case (_, pr, m, Digit.Four(d, c, b, a)) =>
+          ViewR.Cons(new Lazy(FingerTree.deep(pr, m, Digit.Three(d, c, b))), a)
+      }
+    )
 
-      case FingerTree.Deep(_, pr, m, Digit.Three(c, b, a)) =>
-        ViewR.Cons(new Lazy(FingerTree.deep(pr, m, Digit.Two(c, b))), a)
-
-      case FingerTree.Deep(_, pr, m, Digit.Four(d, c, b, a)) =>
-        ViewR.Cons(new Lazy(FingerTree.deep(pr, m, Digit.Three(d, c, b))), a)
-    }
-
-  def lazyListR(implicit measured: Measured[A, V]): LazyList[A] =
+  def lazyListR: LazyList[A] =
     LazyList.unfold(this)(_.viewR match {
       case ViewR.Cons(tail, head) => Some((head, tail.value))
       case ViewR.Empty()          => None
     })
 
-  def headR(implicit measured: Measured[A, V]): A =
+  def headR: A =
     viewR match {
       case ViewR.Cons(_, a) => a
       case ViewR.Empty()    => throw new NoSuchElementException("head of empty finger tree")
     }
 
-  def tailR(implicit measured: Measured[A, V]): FingerTree[V, A] =
+  def tailR: FingerTree[V, A] =
     viewR match {
       case ViewR.Cons(rest, _) => rest.value
       case ViewR.Empty()       => throw new NoSuchElementException("tail of empty finger tree")
     }
 
-  def headROption(implicit measured: Measured[A, V]): Option[A] =
+  def headROption: Option[A] =
     viewR match {
       case ViewR.Cons(_, a) => Some(a)
       case ViewR.Empty()    => None
     }
 
-  def tailROption(implicit measured: Measured[A, V]): Option[FingerTree[V, A]] =
+  def tailROption: Option[FingerTree[V, A]] =
     viewR match {
       case ViewR.Cons(rest, _) => Some(rest.value)
       case ViewR.Empty()       => None
@@ -212,18 +200,48 @@ sealed trait FingerTree[V, +A] {
 }
 
 object FingerTree {
-  private[phalange] case class Empty[V]() extends FingerTree[V, Nothing]
-  private[phalange] case class Single[V, +A](x: A) extends FingerTree[V, A]
-  private[phalange] case class Deep[V, A](v: Lazy[V], pr: Digit[A], m: Lazy[FingerTree[V, Node[V, A]]], sf: Digit[A])
-      extends FingerTree[V, A]
+  private[phalange] def empty[V, A](implicit measured: Measured[A, V]): FingerTree[V, A] =
+    new FingerTree[V, A] {
+      protected[phalange] override def fold[B](
+          empty: => B,
+          single: A => B,
+          deep: (Lazy[V], Digit[A], Lazy[FingerTree[V, Node[V, A]]], Digit[A]) => B
+      ): B =
+        empty
+    }
 
-  private[phalange] def deep[V, A](pr: Digit[A], m: Lazy[FingerTree[V, Node[V, A]]], sf: Digit[A])(implicit measured: Measured[A, V]): FingerTree[V, A] =
-    FingerTree.Deep(
-      new Lazy(measured.append(measured.append(Measured.measure[Digit[A], V](pr), Measured.measure[FingerTree[V, Node[V, A]], V](m.value)), Measured.measure[Digit[A], V](sf))),
-      pr,
-      m,
-      sf
-    )
+  private[phalange] def single[V, A](a: A)(implicit measured: Measured[A, V]): FingerTree[V, A] =
+    new FingerTree[V, A] {
+      protected[phalange] override def fold[B](
+          empty: => B,
+          single: A => B,
+          deep: (Lazy[V], Digit[A], Lazy[FingerTree[V, Node[V, A]]], Digit[A]) => B
+      ): B =
+        single(a)
+    }
+
+  private[phalange] def deep[V, A](pr: Digit[A], m: Lazy[FingerTree[V, Node[V, A]]], sf: Digit[A])(implicit
+      measured: Measured[A, V]
+  ): FingerTree[V, A] =
+    new FingerTree[V, A] {
+      protected[phalange] override def fold[B](
+          empty: => B,
+          single: A => B,
+          deep: (Lazy[V], Digit[A], Lazy[FingerTree[V, Node[V, A]]], Digit[A]) => B
+      ): B =
+        deep(
+          new Lazy(
+            measured.append(
+              measured
+                .append(Measured.measure[Digit[A], V](pr), Measured.measure[FingerTree[V, Node[V, A]], V](m.value)),
+              Measured.measure[Digit[A], V](sf)
+            )
+          ),
+          pr,
+          m,
+          sf
+        )
+    }
 
   private[phalange] def nodes[V, A](a: A, b: A, rest: A*)(implicit measured: Measured[A, V]): List[Node[V, A]] =
     if (rest.isEmpty)
@@ -235,48 +253,64 @@ object FingerTree {
     else
       Node.node3(a, b, rest.head) :: nodes(rest.tail.head, rest.tail.tail.head, rest.tail.tail.tail: _*)
 
-  private[phalange] def app3[V, A](a: FingerTree[V, A], b: List[A], c: FingerTree[V, A])(implicit measured: Measured[A, V]): FingerTree[V, A] =
-    (a, b, c) match {
-      case (FingerTree.Empty(), ts, xs) =>
-        ts.foldRight(xs)(_ +: _)
+  private[phalange] def app3[V, A](a: FingerTree[V, A], b: List[A], c: FingerTree[V, A])(implicit
+      measured: Measured[A, V]
+  ): FingerTree[V, A] =
+    a.fold(
+      empty = b.foldRight(c)(_ +: _),
+      single = x => x +: (b.foldRight(c)(_ +: _)),
+      deep = (_, pr1, m1, sf1) =>
+        c.fold(
+          empty = b.foldLeft(a)(_ :+ _),
+          single = x => b.foldLeft(a)(_ :+ _) :+ x,
+          deep = (_, pr2, m2, sf2) =>
+            (pr1, m1, sf1, b, pr2, m2, sf2) match {
+              case (pr1, m1, Digit.One(a), Nil, Digit.One(b), m2, sf2) =>
+                FingerTree.deep(pr1, new Lazy(app3(m1.value, nodes(a, b), m2.value)), sf2)
 
-      case (xs, ts, FingerTree.Empty()) =>
-        ts.foldLeft(xs)(_ :+ _)
+              case (pr1, m1, Digit.One(a), Nil, Digit.Two(b, c), m2, sf2) =>
+                FingerTree.deep(pr1, new Lazy(app3(m1.value, nodes(a, b, c), m2.value)), sf2)
 
-      case (FingerTree.Single(x), ts, xs) =>
-        x +: (ts.foldRight(xs)(_ +: _))
+              case (pr1, m1, Digit.One(a), Nil, Digit.Three(b, c, d), m2, sf2) =>
+                FingerTree.deep(pr1, new Lazy(app3(m1.value, nodes(a, b, c, d), m2.value)), sf2)
 
-      case (xs, ts, FingerTree.Single(x)) =>
-        (ts.foldLeft(xs)(_ :+ _)) :+ x
+              case (pr1, m1, Digit.One(a), Nil, Digit.Four(b, c, d, e), m2, sf2) =>
+                FingerTree.deep(pr1, new Lazy(app3(m1.value, nodes(a, b, c, d, e), m2.value)), sf2)
 
-      case (FingerTree.Deep(_, pr1, m1, Digit.One(a)), Nil, FingerTree.Deep(_, Digit.One(b), m2, sf2)) =>
-        FingerTree.deep(pr1, new Lazy(app3(m1.value, nodes(a, b), m2.value)), sf2)
+              case (pr1, m1, Digit.One(a), ts, pr2, m2, sf2) =>
+                FingerTree.deep(
+                  pr1,
+                  new Lazy(app3(m1.value, nodes(a, ts.head, (ts.tail ++ pr2.toSeq): _*), m2.value)),
+                  sf2
+                )
 
-      case (FingerTree.Deep(_, pr1, m1, Digit.One(a)), Nil, FingerTree.Deep(_, Digit.Two(b, c), m2, sf2)) =>
-        FingerTree.deep(pr1, new Lazy(app3(m1.value, nodes(a, b, c), m2.value)), sf2)
+              case (pr1, m1, Digit.Two(a, b), ts, pr2, m2, sf2) =>
+                FingerTree.deep(pr1, new Lazy(app3(m1.value, nodes(a, b, (ts ++ pr2.toSeq): _*), m2.value)), sf2)
 
-      case (FingerTree.Deep(_, pr1, m1, Digit.One(a)), Nil, FingerTree.Deep(_, Digit.Three(b, c, d), m2, sf2)) =>
-        FingerTree.deep(pr1, new Lazy(app3(m1.value, nodes(a, b, c, d), m2.value)), sf2)
+              case (pr1, m1, Digit.Three(a, b, c), ts, pr2, m2, sf2) =>
+                FingerTree.deep(pr1, new Lazy(app3(m1.value, nodes(a, b, (c +: (ts ++ pr2.toSeq)): _*), m2.value)), sf2)
 
-      case (FingerTree.Deep(_, pr1, m1, Digit.One(a)), Nil, FingerTree.Deep(_, Digit.Four(b, c, d, e), m2, sf2)) =>
-        FingerTree.deep(pr1, new Lazy(app3(m1.value, nodes(a, b, c, d, e), m2.value)), sf2)
+              case (pr1, m1, Digit.Four(a, b, c, d), ts, pr2, m2, sf2) =>
+                FingerTree.deep(
+                  pr1,
+                  new Lazy(app3(m1.value, nodes(a, b, (Seq(c, d) ++ ts ++ pr2.toSeq): _*), m2.value)),
+                  sf2
+                )
+            }
+        )
+    )
 
-      case (FingerTree.Deep(_, pr1, m1, Digit.One(a)), ts, FingerTree.Deep(_, pr2, m2, sf2)) =>
-        FingerTree.deep(pr1, new Lazy(app3(m1.value, nodes(a, ts.head, (ts.tail ++ pr2.toSeq): _*), m2.value)), sf2)
-
-      case (FingerTree.Deep(_, pr1, m1, Digit.Two(a, b)), ts, FingerTree.Deep(_, pr2, m2, sf2)) =>
-        FingerTree.deep(pr1, new Lazy(app3(m1.value, nodes(a, b, (ts ++ pr2.toSeq): _*), m2.value)), sf2)
-
-      case (FingerTree.Deep(_, pr1, m1, Digit.Three(a, b, c)), ts, FingerTree.Deep(_, pr2, m2, sf2)) =>
-        FingerTree.deep(pr1, new Lazy(app3(m1.value, nodes(a, b, (c +: (ts ++ pr2.toSeq)): _*), m2.value)), sf2)
-
-      case (FingerTree.Deep(_, pr1, m1, Digit.Four(a, b, c, d)), ts, FingerTree.Deep(_, pr2, m2, sf2)) =>
-        FingerTree.deep(pr1, new Lazy(app3(m1.value, nodes(a, b, (Seq(c, d) ++ ts ++ pr2.toSeq): _*), m2.value)), sf2)
-    }
-
-  def empty[V, A]: FingerTree[V, A] =
-    Empty()
-
-  def apply[V, A](as: A*)(implicit measured: Measured[A, V]): FingerTree[V, A] =
+  def measured[V, A](as: A*)(implicit measured: Measured[A, V]): FingerTree[V, A] =
     as.foldRight(FingerTree.empty[V, A])(_ +: _)
+
+  def apply[A](as: A*): FingerTree[Unit, A] = {
+    implicit val unitMeasured: Measured[A, Unit] =
+      new Measured[A, Unit] {
+        def apply(a: A): Unit = ()
+        def empty: Unit = ()
+        def append(a: Unit, b: Unit) = ()
+      }
+
+    as.foldRight(FingerTree.empty[Unit, A])(_ +: _)
+  }
 }

--- a/src/main/scala/net/jcazevedo/phalange/FingerTree.scala
+++ b/src/main/scala/net/jcazevedo/phalange/FingerTree.scala
@@ -3,7 +3,7 @@ package net.jcazevedo.phalange
 import scala.collection.compat.immutable.LazyList
 
 sealed abstract class FingerTree[V, A](implicit measured: Measured[A, V]) {
-  protected[phalange] def fold[B](
+  private[phalange] def fold[B](
       empty: => B,
       single: A => B,
       deep: (Lazy[V], Digit[A], Lazy[FingerTree[V, Node[V, A]]], Digit[A]) => B
@@ -202,21 +202,13 @@ sealed abstract class FingerTree[V, A](implicit measured: Measured[A, V]) {
 object FingerTree {
   private[phalange] def empty[V, A](implicit measured: Measured[A, V]): FingerTree[V, A] =
     new FingerTree[V, A] {
-      protected[phalange] override def fold[B](
-          empty: => B,
-          single: A => B,
-          deep: (Lazy[V], Digit[A], Lazy[FingerTree[V, Node[V, A]]], Digit[A]) => B
-      ): B =
+      def fold[B](empty: => B, single: A => B,deep: (Lazy[V], Digit[A], Lazy[FingerTree[V, Node[V, A]]], Digit[A]) => B): B =
         empty
     }
 
   private[phalange] def single[V, A](a: A)(implicit measured: Measured[A, V]): FingerTree[V, A] =
     new FingerTree[V, A] {
-      protected[phalange] override def fold[B](
-          empty: => B,
-          single: A => B,
-          deep: (Lazy[V], Digit[A], Lazy[FingerTree[V, Node[V, A]]], Digit[A]) => B
-      ): B =
+      def fold[B](empty: => B, single: A => B,deep: (Lazy[V], Digit[A], Lazy[FingerTree[V, Node[V, A]]], Digit[A]) => B): B =
         single(a)
     }
 
@@ -224,11 +216,7 @@ object FingerTree {
       measured: Measured[A, V]
   ): FingerTree[V, A] =
     new FingerTree[V, A] {
-      protected[phalange] override def fold[B](
-          empty: => B,
-          single: A => B,
-          deep: (Lazy[V], Digit[A], Lazy[FingerTree[V, Node[V, A]]], Digit[A]) => B
-      ): B =
+      def fold[B](empty: => B,single: A => B,deep: (Lazy[V], Digit[A], Lazy[FingerTree[V, Node[V, A]]], Digit[A]) => B): B =
         deep(
           new Lazy(
             measured.append(measured.append(Measured.measure(pr), Measured.measure(m.value)), Measured.measure(sf))

--- a/src/main/scala/net/jcazevedo/phalange/FingerTree.scala
+++ b/src/main/scala/net/jcazevedo/phalange/FingerTree.scala
@@ -2,236 +2,254 @@ package net.jcazevedo.phalange
 
 import scala.collection.compat.immutable.LazyList
 
-sealed trait FingerTree[+A] {
+sealed trait FingerTree[V, +A] {
   def foldRight[B](z: B)(op: (A, B) => B): B =
     this match {
-      case FingerTree.Empty =>
+      case FingerTree.Empty() =>
         z
 
       case FingerTree.Single(x) =>
         op(x, z)
 
-      case FingerTree.Deep(pr, m, sf) =>
+      case FingerTree.Deep(_, pr, m, sf) =>
         pr.foldRight(m.value.foldRight(sf.foldRight(z)(op))((a, b) => a.foldRight(b)(op)))(op)
     }
 
   def foldLeft[B](z: B)(op: (B, A) => B): B =
     this match {
-      case FingerTree.Empty =>
+      case FingerTree.Empty() =>
         z
 
       case FingerTree.Single(x) =>
         op(z, x)
 
-      case FingerTree.Deep(pr, m, sf) =>
+      case FingerTree.Deep(_, pr, m, sf) =>
         sf.foldLeft(m.value.foldLeft(pr.foldLeft(z)(op))((b, a) => a.foldLeft(b)(op)))(op)
     }
 
-  def +:[B >: A](a: B): FingerTree[B] =
+  def +:[B >: A](a: B)(implicit measured: Measured[B, V], monoid: Monoid[V]): FingerTree[V, B] =
     this match {
-      case FingerTree.Empty =>
+      case FingerTree.Empty() =>
         FingerTree.Single(a)
 
       case FingerTree.Single(b) =>
-        FingerTree.Deep(Digit.One(a), new Lazy(FingerTree.Empty), Digit.One(b))
+        FingerTree.deep(Digit.One(a), new Lazy(FingerTree.Empty()), Digit.One(b))
 
-      case FingerTree.Deep(Digit.One(b), m, sf) =>
-        FingerTree.Deep(Digit.Two(a, b), m, sf)
+      case FingerTree.Deep(_, Digit.One(b), m, sf) =>
+        FingerTree.deep(Digit.Two(a, b), m, sf)
 
-      case FingerTree.Deep(Digit.Two(b, c), m, sf) =>
-        FingerTree.Deep(Digit.Three(a, b, c), m, sf)
+      case FingerTree.Deep(_, Digit.Two(b, c), m, sf) =>
+        FingerTree.deep(Digit.Three(a, b, c), m, sf)
 
-      case FingerTree.Deep(Digit.Three(b, c, d), m, sf) =>
-        FingerTree.Deep(Digit.Four(a, b, c, d), m, sf)
+      case FingerTree.Deep(_, Digit.Three(b, c, d), m, sf) =>
+        FingerTree.deep(Digit.Four(a, b, c, d), m, sf)
 
-      case FingerTree.Deep(Digit.Four(b, c, d, e), m, sf) =>
-        FingerTree.Deep(Digit.Two(a, b), new Lazy(Node.Node3(c, d, e) +: m.value), sf)
+      case FingerTree.Deep(_, Digit.Four(b, c, d, e), m, sf) =>
+        FingerTree.deep(Digit.Two(a, b), new Lazy(Node.node3(c, d, e) +: m.value), sf)
     }
 
-  def :+[B >: A](a: B): FingerTree[B] =
+  def :+[B >: A](a: B)(implicit measured: Measured[B, V], monoid: Monoid[V]): FingerTree[V, B] =
     this match {
-      case FingerTree.Empty =>
+      case FingerTree.Empty() =>
         FingerTree.Single(a)
 
       case FingerTree.Single(b) =>
-        FingerTree.Deep(Digit.One(b), new Lazy(FingerTree.Empty), Digit.One(a))
+        FingerTree.deep(Digit.One(b), new Lazy(FingerTree.Empty()), Digit.One(a))
 
-      case FingerTree.Deep(pr, m, Digit.One(b)) =>
-        FingerTree.Deep(pr, m, Digit.Two(b, a))
+      case FingerTree.Deep(_, pr, m, Digit.One(b)) =>
+        FingerTree.deep(pr, m, Digit.Two(b, a))
 
-      case FingerTree.Deep(pr, m, Digit.Two(c, b)) =>
-        FingerTree.Deep(pr, m, Digit.Three(c, b, a))
+      case FingerTree.Deep(_, pr, m, Digit.Two(c, b)) =>
+        FingerTree.deep(pr, m, Digit.Three(c, b, a))
 
-      case FingerTree.Deep(pr, m, Digit.Three(d, c, b)) =>
-        FingerTree.Deep(pr, m, Digit.Four(d, c, b, a))
+      case FingerTree.Deep(_, pr, m, Digit.Three(d, c, b)) =>
+        FingerTree.deep(pr, m, Digit.Four(d, c, b, a))
 
-      case FingerTree.Deep(pr, m, Digit.Four(e, d, c, b)) =>
-        FingerTree.Deep(pr, new Lazy(m.value :+ Node.Node3(e, d, c)), Digit.Two(b, a))
+      case FingerTree.Deep(_, pr, m, Digit.Four(e, d, c, b)) =>
+        FingerTree.deep(pr, new Lazy(m.value :+ Node.node3(e, d, c)), Digit.Two(b, a))
     }
 
-  def ++[B >: A](that: FingerTree[B]): FingerTree[B] =
+  def ++[B >: A](that: FingerTree[V, B])(implicit measured: Measured[B, V], monoid: Monoid[V]): FingerTree[V, B] =
     FingerTree.app3(this, List.empty, that)
 
-  private def viewL: ViewL[A] =
+  private def viewL(implicit measured: Measured[A, V], monoid: Monoid[V]): ViewL[V, A] =
     this match {
-      case FingerTree.Empty =>
-        ViewL.Empty
+      case FingerTree.Empty() =>
+        ViewL.Empty()
 
       case FingerTree.Single(a) =>
         ViewL.Cons(a, new Lazy(FingerTree.empty))
 
-      case FingerTree.Deep(Digit.One(a), m, sf) =>
+      case FingerTree.Deep(_, Digit.One(a), m, sf) =>
         ViewL.Cons(
           a,
           new Lazy(m.value.viewL match {
-            case ViewL.Empty =>
+            case ViewL.Empty() =>
               FingerTree.apply(sf.toSeq: _*)
 
-            case ViewL.Cons(Node.Node2(a, b), rest) =>
-              FingerTree.Deep(Digit.Two(a, b), rest, sf)
+            case ViewL.Cons(Node.Node2(_, a, b), rest) =>
+              FingerTree.deep(Digit.Two(a, b), rest, sf)
 
-            case ViewL.Cons(Node.Node3(a, b, c), rest) =>
-              FingerTree.Deep(Digit.Three(a, b, c), rest, sf)
+            case ViewL.Cons(Node.Node3(_, a, b, c), rest) =>
+              FingerTree.deep(Digit.Three(a, b, c), rest, sf)
           })
         )
 
-      case FingerTree.Deep(Digit.Two(a, b), m, sf) =>
-        ViewL.Cons(a, new Lazy(FingerTree.Deep(Digit.One(b), m, sf)))
+      case FingerTree.Deep(_, Digit.Two(a, b), m, sf) =>
+        ViewL.Cons(a, new Lazy(FingerTree.deep(Digit.One(b), m, sf)))
 
-      case FingerTree.Deep(Digit.Three(a, b, c), m, sf) =>
-        ViewL.Cons(a, new Lazy(FingerTree.Deep(Digit.Two(b, c), m, sf)))
+      case FingerTree.Deep(_, Digit.Three(a, b, c), m, sf) =>
+        ViewL.Cons(a, new Lazy(FingerTree.deep(Digit.Two(b, c), m, sf)))
 
-      case FingerTree.Deep(Digit.Four(a, b, c, d), m, sf) =>
-        ViewL.Cons(a, new Lazy(FingerTree.Deep(Digit.Three(b, c, d), m, sf)))
+      case FingerTree.Deep(_, Digit.Four(a, b, c, d), m, sf) =>
+        ViewL.Cons(a, new Lazy(FingerTree.deep(Digit.Three(b, c, d), m, sf)))
     }
 
-  def lazyListL: LazyList[A] =
+  def lazyListL(implicit measured: Measured[A, V], monoid: Monoid[V]): LazyList[A] =
     LazyList.unfold(this)(_.viewL match {
       case ViewL.Cons(head, tail) => Some((head, tail.value))
-      case ViewL.Empty            => None
+      case ViewL.Empty()          => None
     })
 
-  def toList: List[A] =
+  def toList(implicit measured: Measured[A, V], monoid: Monoid[V]): List[A] =
     lazyListL.toList
 
-  def isEmpty: Boolean =
+  def isEmpty(implicit measured: Measured[A, V], monoid: Monoid[V]): Boolean =
     viewL match {
       case ViewL.Cons(_, _) => false
-      case ViewL.Empty      => true
+      case ViewL.Empty()    => true
     }
 
-  def nonEmpty: Boolean =
+  def nonEmpty(implicit measured: Measured[A, V], monoid: Monoid[V]): Boolean =
     !isEmpty
 
-  def headL: A =
+  def headL(implicit measured: Measured[A, V], monoid: Monoid[V]): A =
     viewL match {
       case ViewL.Cons(a, _) => a
-      case ViewL.Empty      => throw new NoSuchElementException("head of empty finger tree")
+      case ViewL.Empty()    => throw new NoSuchElementException("head of empty finger tree")
     }
 
-  def tailL: FingerTree[A] =
+  def tailL(implicit measured: Measured[A, V], monoid: Monoid[V]): FingerTree[V, A] =
     viewL match {
       case ViewL.Cons(_, rest) => rest.value
-      case ViewL.Empty         => throw new NoSuchElementException("tail of empty finger tree")
+      case ViewL.Empty()       => throw new NoSuchElementException("tail of empty finger tree")
     }
 
-  def headLOption: Option[A] =
+  def headLOption(implicit measured: Measured[A, V], monoid: Monoid[V]): Option[A] =
     viewL match {
       case ViewL.Cons(a, _) => Some(a)
-      case ViewL.Empty      => None
+      case ViewL.Empty()    => None
     }
 
-  def tailLOption: Option[FingerTree[A]] =
+  def tailLOption(implicit measured: Measured[A, V], monoid: Monoid[V]): Option[FingerTree[V, A]] =
     viewL match {
       case ViewL.Cons(_, rest) => Some(rest.value)
-      case ViewL.Empty         => None
+      case ViewL.Empty()       => None
     }
 
-  private def viewR: ViewR[A] =
+  private def viewR(implicit measured: Measured[A, V], monoid: Monoid[V]): ViewR[V, A] =
     this match {
-      case FingerTree.Empty =>
-        ViewR.Empty
+      case FingerTree.Empty() =>
+        ViewR.Empty()
 
       case FingerTree.Single(a) =>
         ViewR.Cons(new Lazy(FingerTree.empty), a)
 
-      case FingerTree.Deep(pr, m, Digit.One(a)) =>
+      case FingerTree.Deep(_, pr, m, Digit.One(a)) =>
         ViewR.Cons(
           new Lazy(m.value.viewR match {
-            case ViewR.Empty =>
+            case ViewR.Empty() =>
               FingerTree.apply(pr.toSeq: _*)
 
-            case ViewR.Cons(rest, Node.Node2(b, a)) =>
-              FingerTree.Deep(pr, rest, Digit.Two(b, a))
+            case ViewR.Cons(rest, Node.Node2(_, b, a)) =>
+              FingerTree.deep(pr, rest, Digit.Two(b, a))
 
-            case ViewR.Cons(rest, Node.Node3(c, b, a)) =>
-              FingerTree.Deep(pr, rest, Digit.Three(c, b, a))
+            case ViewR.Cons(rest, Node.Node3(_, c, b, a)) =>
+              FingerTree.deep(pr, rest, Digit.Three(c, b, a))
           }),
           a
         )
 
-      case FingerTree.Deep(pr, m, Digit.Two(b, a)) =>
-        ViewR.Cons(new Lazy(FingerTree.Deep(pr, m, Digit.One(b))), a)
+      case FingerTree.Deep(_, pr, m, Digit.Two(b, a)) =>
+        ViewR.Cons(new Lazy(FingerTree.deep(pr, m, Digit.One(b))), a)
 
-      case FingerTree.Deep(pr, m, Digit.Three(c, b, a)) =>
-        ViewR.Cons(new Lazy(FingerTree.Deep(pr, m, Digit.Two(c, b))), a)
+      case FingerTree.Deep(_, pr, m, Digit.Three(c, b, a)) =>
+        ViewR.Cons(new Lazy(FingerTree.deep(pr, m, Digit.Two(c, b))), a)
 
-      case FingerTree.Deep(pr, m, Digit.Four(d, c, b, a)) =>
-        ViewR.Cons(new Lazy(FingerTree.Deep(pr, m, Digit.Three(d, c, b))), a)
+      case FingerTree.Deep(_, pr, m, Digit.Four(d, c, b, a)) =>
+        ViewR.Cons(new Lazy(FingerTree.deep(pr, m, Digit.Three(d, c, b))), a)
     }
 
-  def lazyListR: LazyList[A] =
+  def lazyListR(implicit measured: Measured[A, V], monoid: Monoid[V]): LazyList[A] =
     LazyList.unfold(this)(_.viewR match {
       case ViewR.Cons(tail, head) => Some((head, tail.value))
-      case ViewR.Empty            => None
+      case ViewR.Empty()          => None
     })
 
-  def headR: A =
+  def headR(implicit measured: Measured[A, V], monoid: Monoid[V]): A =
     viewR match {
       case ViewR.Cons(_, a) => a
-      case ViewR.Empty      => throw new NoSuchElementException("head of empty finger tree")
+      case ViewR.Empty()    => throw new NoSuchElementException("head of empty finger tree")
     }
 
-  def tailR: FingerTree[A] =
+  def tailR(implicit measured: Measured[A, V], monoid: Monoid[V]): FingerTree[V, A] =
     viewR match {
       case ViewR.Cons(rest, _) => rest.value
-      case ViewR.Empty         => throw new NoSuchElementException("tail of empty finger tree")
+      case ViewR.Empty()       => throw new NoSuchElementException("tail of empty finger tree")
     }
 
-  def headROption: Option[A] =
+  def headROption(implicit measured: Measured[A, V], monoid: Monoid[V]): Option[A] =
     viewR match {
       case ViewR.Cons(_, a) => Some(a)
-      case ViewR.Empty      => None
+      case ViewR.Empty()    => None
     }
 
-  def tailROption: Option[FingerTree[A]] =
+  def tailROption(implicit measured: Measured[A, V], monoid: Monoid[V]): Option[FingerTree[V, A]] =
     viewR match {
       case ViewR.Cons(rest, _) => Some(rest.value)
-      case ViewR.Empty         => None
+      case ViewR.Empty()       => None
     }
 }
 
 object FingerTree {
-  private[phalange] case object Empty extends FingerTree[Nothing]
-  private[phalange] case class Single[+A](x: A) extends FingerTree[A]
-  private[phalange] case class Deep[A](pr: Digit[A], m: Lazy[FingerTree[Node[A]]], sf: Digit[A]) extends FingerTree[A]
+  private[phalange] case class Empty[V]() extends FingerTree[V, Nothing]
+  private[phalange] case class Single[V, +A](x: A) extends FingerTree[V, A]
+  private[phalange] case class Deep[V, A](v: Lazy[V], pr: Digit[A], m: Lazy[FingerTree[V, Node[V, A]]], sf: Digit[A])
+      extends FingerTree[V, A]
 
-  private[phalange] def nodes[A](a: A, b: A, rest: A*): List[Node[A]] =
+  private[phalange] def deep[V, A](pr: Digit[A], m: Lazy[FingerTree[V, Node[V, A]]], sf: Digit[A])(implicit
+      measured: Measured[A, V],
+      monoid: Monoid[V]
+  ): FingerTree[V, A] =
+    FingerTree.Deep(
+      new Lazy(monoid.append(monoid.append(Measured.measure(pr), Measured.measure(m.value)), Measured.measure(sf))),
+      pr,
+      m,
+      sf
+    )
+
+  private[phalange] def nodes[V, A](a: A, b: A, rest: A*)(implicit
+      measured: Measured[A, V],
+      monoid: Monoid[V]
+  ): List[Node[V, A]] =
     if (rest.isEmpty)
-      List(Node.Node2(a, b))
+      List(Node.node2(a, b))
     else if (rest.length == 1)
-      List(Node.Node3(a, b, rest.head))
+      List(Node.node3(a, b, rest.head))
     else if (rest.length == 2)
-      List(Node.Node2(a, b), Node.Node2(rest.head, rest.tail.head))
+      List(Node.node2(a, b), Node.node2(rest.head, rest.tail.head))
     else
-      Node.Node3(a, b, rest.head) :: nodes(rest.tail.head, rest.tail.tail.head, rest.tail.tail.tail: _*)
+      Node.node3(a, b, rest.head) :: nodes(rest.tail.head, rest.tail.tail.head, rest.tail.tail.tail: _*)
 
-  private[phalange] def app3[A](a: FingerTree[A], b: List[A], c: FingerTree[A]): FingerTree[A] =
+  private[phalange] def app3[V, A](a: FingerTree[V, A], b: List[A], c: FingerTree[V, A])(implicit
+      measured: Measured[A, V],
+      monoid: Monoid[V]
+  ): FingerTree[V, A] =
     (a, b, c) match {
-      case (FingerTree.Empty, ts, xs) =>
+      case (FingerTree.Empty(), ts, xs) =>
         ts.foldRight(xs)(_ +: _)
 
-      case (xs, ts, FingerTree.Empty) =>
+      case (xs, ts, FingerTree.Empty()) =>
         ts.foldLeft(xs)(_ :+ _)
 
       case (FingerTree.Single(x), ts, xs) =>
@@ -240,34 +258,34 @@ object FingerTree {
       case (xs, ts, FingerTree.Single(x)) =>
         (ts.foldLeft(xs)(_ :+ _)) :+ x
 
-      case (FingerTree.Deep(pr1, m1, Digit.One(a)), Nil, FingerTree.Deep(Digit.One(b), m2, sf2)) =>
-        FingerTree.Deep(pr1, new Lazy(app3(m1.value, nodes(a, b), m2.value)), sf2)
+      case (FingerTree.Deep(_, pr1, m1, Digit.One(a)), Nil, FingerTree.Deep(_, Digit.One(b), m2, sf2)) =>
+        FingerTree.deep(pr1, new Lazy(app3(m1.value, nodes(a, b), m2.value)), sf2)
 
-      case (FingerTree.Deep(pr1, m1, Digit.One(a)), Nil, FingerTree.Deep(Digit.Two(b, c), m2, sf2)) =>
-        FingerTree.Deep(pr1, new Lazy(app3(m1.value, nodes(a, b, c), m2.value)), sf2)
+      case (FingerTree.Deep(_, pr1, m1, Digit.One(a)), Nil, FingerTree.Deep(_, Digit.Two(b, c), m2, sf2)) =>
+        FingerTree.deep(pr1, new Lazy(app3(m1.value, nodes(a, b, c), m2.value)), sf2)
 
-      case (FingerTree.Deep(pr1, m1, Digit.One(a)), Nil, FingerTree.Deep(Digit.Three(b, c, d), m2, sf2)) =>
-        FingerTree.Deep(pr1, new Lazy(app3(m1.value, nodes(a, b, c, d), m2.value)), sf2)
+      case (FingerTree.Deep(_, pr1, m1, Digit.One(a)), Nil, FingerTree.Deep(_, Digit.Three(b, c, d), m2, sf2)) =>
+        FingerTree.deep(pr1, new Lazy(app3(m1.value, nodes(a, b, c, d), m2.value)), sf2)
 
-      case (FingerTree.Deep(pr1, m1, Digit.One(a)), Nil, FingerTree.Deep(Digit.Four(b, c, d, e), m2, sf2)) =>
-        FingerTree.Deep(pr1, new Lazy(app3(m1.value, nodes(a, b, c, d, e), m2.value)), sf2)
+      case (FingerTree.Deep(_, pr1, m1, Digit.One(a)), Nil, FingerTree.Deep(_, Digit.Four(b, c, d, e), m2, sf2)) =>
+        FingerTree.deep(pr1, new Lazy(app3(m1.value, nodes(a, b, c, d, e), m2.value)), sf2)
 
-      case (FingerTree.Deep(pr1, m1, Digit.One(a)), ts, FingerTree.Deep(pr2, m2, sf2)) =>
-        FingerTree.Deep(pr1, new Lazy(app3(m1.value, nodes(a, ts.head, (ts.tail ++ pr2.toSeq): _*), m2.value)), sf2)
+      case (FingerTree.Deep(_, pr1, m1, Digit.One(a)), ts, FingerTree.Deep(_, pr2, m2, sf2)) =>
+        FingerTree.deep(pr1, new Lazy(app3(m1.value, nodes(a, ts.head, (ts.tail ++ pr2.toSeq): _*), m2.value)), sf2)
 
-      case (FingerTree.Deep(pr1, m1, Digit.Two(a, b)), ts, FingerTree.Deep(pr2, m2, sf2)) =>
-        FingerTree.Deep(pr1, new Lazy(app3(m1.value, nodes(a, b, (ts ++ pr2.toSeq): _*), m2.value)), sf2)
+      case (FingerTree.Deep(_, pr1, m1, Digit.Two(a, b)), ts, FingerTree.Deep(_, pr2, m2, sf2)) =>
+        FingerTree.deep(pr1, new Lazy(app3(m1.value, nodes(a, b, (ts ++ pr2.toSeq): _*), m2.value)), sf2)
 
-      case (FingerTree.Deep(pr1, m1, Digit.Three(a, b, c)), ts, FingerTree.Deep(pr2, m2, sf2)) =>
-        FingerTree.Deep(pr1, new Lazy(app3(m1.value, nodes(a, b, (c +: (ts ++ pr2.toSeq)): _*), m2.value)), sf2)
+      case (FingerTree.Deep(_, pr1, m1, Digit.Three(a, b, c)), ts, FingerTree.Deep(_, pr2, m2, sf2)) =>
+        FingerTree.deep(pr1, new Lazy(app3(m1.value, nodes(a, b, (c +: (ts ++ pr2.toSeq)): _*), m2.value)), sf2)
 
-      case (FingerTree.Deep(pr1, m1, Digit.Four(a, b, c, d)), ts, FingerTree.Deep(pr2, m2, sf2)) =>
-        FingerTree.Deep(pr1, new Lazy(app3(m1.value, nodes(a, b, (Seq(c, d) ++ ts ++ pr2.toSeq): _*), m2.value)), sf2)
+      case (FingerTree.Deep(_, pr1, m1, Digit.Four(a, b, c, d)), ts, FingerTree.Deep(_, pr2, m2, sf2)) =>
+        FingerTree.deep(pr1, new Lazy(app3(m1.value, nodes(a, b, (Seq(c, d) ++ ts ++ pr2.toSeq): _*), m2.value)), sf2)
     }
 
-  def empty[A]: FingerTree[A] =
-    Empty
+  def empty[V, A]: FingerTree[V, A] =
+    Empty()
 
-  def apply[A](as: A*): FingerTree[A] =
-    as.foldRight(FingerTree.empty[A])(_ +: _)
+  def apply[V, A](as: A*)(implicit measured: Measured[A, V], monoid: Monoid[V]): FingerTree[V, A] =
+    as.foldRight(FingerTree.empty[V, A])(_ +: _)
 }

--- a/src/main/scala/net/jcazevedo/phalange/FingerTree.scala
+++ b/src/main/scala/net/jcazevedo/phalange/FingerTree.scala
@@ -41,7 +41,7 @@ sealed abstract class FingerTree[V, A](implicit measured: Measured[A, V]) {
           FingerTree.deep(Digit.Four(a, b, c, d), m, sf)
 
         case (_, Digit.Four(b, c, d, e), m, sf) =>
-          FingerTree.deep(Digit.Two(a, b), new Lazy(Node.node3(c, d, e) +: m.value), sf)
+          FingerTree.deep(Digit.Two(a, b), new Lazy(Node(c, d, e) +: m.value), sf)
       }
     )
 
@@ -60,7 +60,7 @@ sealed abstract class FingerTree[V, A](implicit measured: Measured[A, V]) {
           FingerTree.deep(pr, m, Digit.Four(d, c, b, a))
 
         case (_, pr, m, Digit.Four(e, d, c, b)) =>
-          FingerTree.deep(pr, new Lazy(m.value :+ Node.node3(e, d, c)), Digit.Two(b, a))
+          FingerTree.deep(pr, new Lazy(m.value :+ Node(e, d, c)), Digit.Two(b, a))
       }
     )
 
@@ -79,11 +79,11 @@ sealed abstract class FingerTree[V, A](implicit measured: Measured[A, V]) {
               case ViewL.Empty() =>
                 FingerTree.measured(sf.toSeq: _*)
 
-              case ViewL.Cons(Node.Node2(_, a, b), rest) =>
-                FingerTree.deep(Digit.Two(a, b), rest, sf)
-
-              case ViewL.Cons(Node.Node3(_, a, b, c), rest) =>
-                FingerTree.deep(Digit.Three(a, b, c), rest, sf)
+              case ViewL.Cons(node, rest) =>
+                node.fold(
+                  node2 = (_, a, b) => FingerTree.deep(Digit.Two(a, b), rest, sf),
+                  node3 = (_, a, b, c) => FingerTree.deep(Digit.Three(a, b, c), rest, sf)
+                )
             })
           )
 
@@ -151,11 +151,11 @@ sealed abstract class FingerTree[V, A](implicit measured: Measured[A, V]) {
               case ViewR.Empty() =>
                 FingerTree.measured(pr.toSeq: _*)
 
-              case ViewR.Cons(rest, Node.Node2(_, b, a)) =>
-                FingerTree.deep(pr, rest, Digit.Two(b, a))
-
-              case ViewR.Cons(rest, Node.Node3(_, c, b, a)) =>
-                FingerTree.deep(pr, rest, Digit.Three(c, b, a))
+              case ViewR.Cons(rest, node) =>
+                node.fold(
+                  node2 = (_, b, a) => FingerTree.deep(pr, rest, Digit.Two(b, a)),
+                  node3 = (_, c, b, a) => FingerTree.deep(pr, rest, Digit.Three(c, b, a))
+                )
             }),
             a
           )
@@ -242,13 +242,13 @@ object FingerTree {
 
   private[phalange] def nodes[V, A](a: A, b: A, rest: A*)(implicit measured: Measured[A, V]): List[Node[V, A]] =
     if (rest.isEmpty)
-      List(Node.node2(a, b))
+      List(Node(a, b))
     else if (rest.length == 1)
-      List(Node.node3(a, b, rest.head))
+      List(Node(a, b, rest.head))
     else if (rest.length == 2)
-      List(Node.node2(a, b), Node.node2(rest.head, rest.tail.head))
+      List(Node(a, b), Node(rest.head, rest.tail.head))
     else
-      Node.node3(a, b, rest.head) :: nodes(rest.tail.head, rest.tail.tail.head, rest.tail.tail.tail: _*)
+      Node(a, b, rest.head) :: nodes(rest.tail.head, rest.tail.tail.head, rest.tail.tail.tail: _*)
 
   private[phalange] def app3[V, A](a: FingerTree[V, A], b: List[A], c: FingerTree[V, A])(implicit
       measured: Measured[A, V]

--- a/src/main/scala/net/jcazevedo/phalange/Measured.scala
+++ b/src/main/scala/net/jcazevedo/phalange/Measured.scala
@@ -8,10 +8,7 @@ object Measured {
   private[phalange] implicit def nodeMeasured[A, V](implicit monoid: Monoid[V]): Measured[Node[V, A], V] =
     new Measured[Node[V, A], V] {
       def apply(a: Node[V, A]): V =
-        a match {
-          case Node.Node2(v, _, _)    => v
-          case Node.Node3(v, _, _, _) => v
-        }
+        a.measure
 
       def empty: V =
         monoid.empty

--- a/src/main/scala/net/jcazevedo/phalange/Measured.scala
+++ b/src/main/scala/net/jcazevedo/phalange/Measured.scala
@@ -7,40 +7,8 @@ trait Measured[-A, V] extends Monoid[V] {
 object Measured {
   private[phalange] implicit def nodeMeasured[A, V](implicit monoid: Monoid[V]): Measured[Node[V, A], V] =
     new Measured[Node[V, A], V] {
-      def apply(a: Node[V, A]): V =
-        a.measure
-
-      def empty: V =
-        monoid.empty
-
-      def append(a: V, b: V) =
-        monoid.append(a, b)
+      def apply(a: Node[V, A]): V = a.measure
+      def empty: V = monoid.empty
+      def append(a: V, b: V) = monoid.append(a, b)
     }
-
-  private[phalange] implicit def digitMeasured[A, V](implicit measured: Measured[A, V]): Measured[Digit[A], V] =
-    new Measured[Digit[A], V] {
-      def apply(a: Digit[A]): V =
-        a match {
-          case Digit.One(a) =>
-            measured.apply(a)
-
-          case Digit.Two(a, b) =>
-            append(measured.apply(a), measured.apply(b))
-
-          case Digit.Three(a, b, c) =>
-            append(append(measured.apply(a), measured.apply(b)), measured.apply(c))
-
-          case Digit.Four(a, b, c, d) =>
-            append(append(append(measured.apply(a), measured.apply(b)), measured.apply(c)), measured.apply(d))
-        }
-
-      def empty: V =
-        measured.empty
-
-      def append(a: V, b: V) =
-        measured.append(a, b)
-    }
-
-  private[phalange] def measure[A, V](a: A)(implicit measured: Measured[A, V]): V =
-    measured.apply(a)
 }

--- a/src/main/scala/net/jcazevedo/phalange/Measured.scala
+++ b/src/main/scala/net/jcazevedo/phalange/Measured.scala
@@ -1,0 +1,56 @@
+package net.jcazevedo.phalange
+
+trait Measured[-A, V] {
+  def apply(a: A): V
+}
+
+object Measured {
+  private[phalange] implicit def nodeMeasured[A, V]: Measured[Node[V, A], V] =
+    new Measured[Node[V, A], V] {
+      def apply(a: Node[V, A]): V =
+        a match {
+          case Node.Node2(v, _, _)    => v
+          case Node.Node3(v, _, _, _) => v
+        }
+    }
+
+  private[phalange] implicit def digitMeasured[A, V](implicit
+      measured: Measured[A, V],
+      monoid: Monoid[V]
+  ): Measured[Digit[A], V] =
+    new Measured[Digit[A], V] {
+      def apply(a: Digit[A]): V =
+        a match {
+          case Digit.One(a) =>
+            measured.apply(a)
+
+          case Digit.Two(a, b) =>
+            monoid.append(measured.apply(a), measured.apply(b))
+
+          case Digit.Three(a, b, c) =>
+            monoid.append(monoid.append(measured.apply(a), measured.apply(b)), measured.apply(c))
+
+          case Digit.Four(a, b, c, d) =>
+            monoid.append(
+              monoid.append(monoid.append(measured.apply(a), measured.apply(b)), measured.apply(c)),
+              measured.apply(d)
+            )
+        }
+    }
+
+  private[phalange] implicit def fingerTreeMeasure[A, V](implicit
+      measured: Measured[A, V],
+      monoid: Monoid[V]
+  ): Measured[FingerTree[V, A], V] =
+    new Measured[FingerTree[V, A], V] {
+      def apply(a: FingerTree[V, A]): V =
+        a match {
+          case FingerTree.Empty()          => monoid.empty
+          case FingerTree.Single(x)        => measured.apply(x)
+          case FingerTree.Deep(v, _, _, _) => v.value
+        }
+    }
+
+  private[phalange] def measure[A, V](a: A)(implicit measured: Measured[A, V]): V =
+    measured.apply(a)
+}

--- a/src/main/scala/net/jcazevedo/phalange/Measured.scala
+++ b/src/main/scala/net/jcazevedo/phalange/Measured.scala
@@ -4,7 +4,7 @@ trait Measured[-A, V] extends Monoid[V] {
   def apply(a: A): V
 }
 
-object Measured {
+object Measured extends LowPriorityImplicits {
   private[phalange] implicit def nodeMeasured[A, V](implicit monoid: Monoid[V]): Measured[Node[V, A], V] =
     new Measured[Node[V, A], V] {
       def apply(a: Node[V, A]): V =
@@ -62,4 +62,16 @@ object Measured {
 
   private[phalange] def measure[A, V](a: A)(implicit measured: Measured[A, V]): V =
     measured.apply(a)
+}
+
+trait LowPriorityImplicits {
+  /**
+   * A default implementation for when we don't want any measurements.
+   */
+  implicit val unitMeasured: Measured[Any, Unit] =
+    new Measured[Any, Unit] {
+      def apply(a: Any): Unit = ()
+      def empty: Unit = ()
+      def append(a: Unit, b: Unit) = ()
+    }
 }

--- a/src/main/scala/net/jcazevedo/phalange/Measured.scala
+++ b/src/main/scala/net/jcazevedo/phalange/Measured.scala
@@ -1,23 +1,26 @@
 package net.jcazevedo.phalange
 
-trait Measured[-A, V] {
+trait Measured[-A, V] extends Monoid[V] {
   def apply(a: A): V
 }
 
 object Measured {
-  private[phalange] implicit def nodeMeasured[A, V]: Measured[Node[V, A], V] =
+  private[phalange] implicit def nodeMeasured[A, V](implicit monoid: Monoid[V]): Measured[Node[V, A], V] =
     new Measured[Node[V, A], V] {
       def apply(a: Node[V, A]): V =
         a match {
           case Node.Node2(v, _, _)    => v
           case Node.Node3(v, _, _, _) => v
         }
+
+      def empty: V =
+        monoid.empty
+
+      def append(a: V, b: V) =
+        monoid.append(a, b)
     }
 
-  private[phalange] implicit def digitMeasured[A, V](implicit
-      measured: Measured[A, V],
-      monoid: Monoid[V]
-  ): Measured[Digit[A], V] =
+  private[phalange] implicit def digitMeasured[A, V](implicit measured: Measured[A, V]): Measured[Digit[A], V] =
     new Measured[Digit[A], V] {
       def apply(a: Digit[A]): V =
         a match {
@@ -25,30 +28,36 @@ object Measured {
             measured.apply(a)
 
           case Digit.Two(a, b) =>
-            monoid.append(measured.apply(a), measured.apply(b))
+            append(measured.apply(a), measured.apply(b))
 
           case Digit.Three(a, b, c) =>
-            monoid.append(monoid.append(measured.apply(a), measured.apply(b)), measured.apply(c))
+            append(append(measured.apply(a), measured.apply(b)), measured.apply(c))
 
           case Digit.Four(a, b, c, d) =>
-            monoid.append(
-              monoid.append(monoid.append(measured.apply(a), measured.apply(b)), measured.apply(c)),
-              measured.apply(d)
-            )
+            append(append(append(measured.apply(a), measured.apply(b)), measured.apply(c)),measured.apply(d))
         }
+
+      def empty: V =
+        measured.empty
+
+      def append(a: V, b: V) =
+        measured.append(a, b)
     }
 
-  private[phalange] implicit def fingerTreeMeasure[A, V](implicit
-      measured: Measured[A, V],
-      monoid: Monoid[V]
-  ): Measured[FingerTree[V, A], V] =
+  private[phalange] implicit def fingerTreeMeasure[A, V](implicit measured: Measured[A, V]): Measured[FingerTree[V, A], V] =
     new Measured[FingerTree[V, A], V] {
       def apply(a: FingerTree[V, A]): V =
         a match {
-          case FingerTree.Empty()          => monoid.empty
+          case FingerTree.Empty()          => empty
           case FingerTree.Single(x)        => measured.apply(x)
           case FingerTree.Deep(v, _, _, _) => v.value
         }
+
+      def empty: V =
+        measured.empty
+
+      def append(a: V, b: V): V =
+        measured.append(a, b)
     }
 
   private[phalange] def measure[A, V](a: A)(implicit measured: Measured[A, V]): V =

--- a/src/main/scala/net/jcazevedo/phalange/Measured.scala
+++ b/src/main/scala/net/jcazevedo/phalange/Measured.scala
@@ -44,20 +44,6 @@ object Measured {
         measured.append(a, b)
     }
 
-  private[phalange] implicit def fingerTreeMeasure[A, V](implicit
-      measured: Measured[A, V]
-  ): Measured[FingerTree[V, A], V] =
-    new Measured[FingerTree[V, A], V] {
-      def apply(a: FingerTree[V, A]): V =
-        a.fold(empty, measured.apply, (v, _, _, _) => v.value)
-
-      def empty: V =
-        measured.empty
-
-      def append(a: V, b: V): V =
-        measured.append(a, b)
-    }
-
   private[phalange] def measure[A, V](a: A)(implicit measured: Measured[A, V]): V =
     measured.apply(a)
 }

--- a/src/main/scala/net/jcazevedo/phalange/Monoid.scala
+++ b/src/main/scala/net/jcazevedo/phalange/Monoid.scala
@@ -1,0 +1,6 @@
+package net.jcazevedo.phalange
+
+trait Monoid[A] {
+  def empty: A
+  def append(a: A, b: A): A
+}

--- a/src/main/scala/net/jcazevedo/phalange/Node.scala
+++ b/src/main/scala/net/jcazevedo/phalange/Node.scala
@@ -3,10 +3,10 @@ package net.jcazevedo.phalange
 private[phalange] sealed abstract class Node[V, +A] extends Iterable[A] {
   private[phalange] def fold[B](node2: (Lazy[V], A, A) => B, node3: (Lazy[V], A, A, A) => B): B
 
-  def measure: V =
+  final def measure: V =
     fold(node2 = (lm, _, _) => lm.value, node3 = (lm, _, _, _) => lm.value)
 
-  def iterator: Iterator[A] =
+  final def iterator: Iterator[A] =
     fold(node2 = (_, a, b) => Iterator(a, b), node3 = (_, a, b, c) => Iterator(a, b, c))
 }
 

--- a/src/main/scala/net/jcazevedo/phalange/Node.scala
+++ b/src/main/scala/net/jcazevedo/phalange/Node.scala
@@ -12,12 +12,9 @@ private[phalange] object Node {
   private[phalange] case class Node2[V, +A](v: V, a: A, b: A) extends Node[V, A]
   private[phalange] case class Node3[V, +A](v: V, a: A, b: A, c: A) extends Node[V, A]
 
-  private[phalange] def node2[V, A](a: A, b: A)(implicit measured: Measured[A, V], monoid: Monoid[V]): Node[V, A] =
-    Node.Node2(monoid.append(measured.apply(a), measured.apply(b)), a, b)
+  private[phalange] def node2[V, A](a: A, b: A)(implicit measured: Measured[A, V]): Node[V, A] =
+    Node.Node2(measured.append(measured.apply(a), measured.apply(b)), a, b)
 
-  private[phalange] def node3[V, A](a: A, b: A, c: A)(implicit
-      measured: Measured[A, V],
-      monoid: Monoid[V]
-  ): Node[V, A] =
-    Node.Node3(monoid.append(monoid.append(measured.apply(a), measured.apply(b)), measured.apply(c)), a, b, c)
+  private[phalange] def node3[V, A](a: A, b: A, c: A)(implicit measured: Measured[A, V]): Node[V, A] =
+    Node.Node3(measured.append(measured.append(measured.apply(a), measured.apply(b)), measured.apply(c)), a, b, c)
 }

--- a/src/main/scala/net/jcazevedo/phalange/Node.scala
+++ b/src/main/scala/net/jcazevedo/phalange/Node.scala
@@ -1,20 +1,30 @@
 package net.jcazevedo.phalange
 
-private[phalange] sealed trait Node[V, +A] extends Iterable[A] {
+private[phalange] sealed abstract class Node[V, +A] extends Iterable[A] {
+  private[phalange] def fold[B](node2: (Lazy[V], A, A) => B, node3: (Lazy[V], A, A, A) => B): B
+
+  def measure: V =
+    fold(node2 = (lm, _, _) => lm.value, node3 = (lm, _, _, _) => lm.value)
+
   def iterator: Iterator[A] =
-    this match {
-      case Node.Node2(_, a, b)    => Iterator(a, b)
-      case Node.Node3(_, a, b, c) => Iterator(a, b, c)
-    }
+    fold(node2 = (_, a, b) => Iterator(a, b), node3 = (_, a, b, c) => Iterator(a, b, c))
 }
 
 private[phalange] object Node {
-  private[phalange] case class Node2[V, +A](v: V, a: A, b: A) extends Node[V, A]
-  private[phalange] case class Node3[V, +A](v: V, a: A, b: A, c: A) extends Node[V, A]
+  private[phalange] def apply[V, A](a: A, b: A)(implicit measured: Measured[A, V]): Node[V, A] =
+    new Node[V, A] {
+      def fold[B](node2: (Lazy[V], A, A) => B, node3: (Lazy[V], A, A, A) => B): B =
+        node2(new Lazy(measured.append(measured.apply(a), measured.apply(b))), a, b)
+    }
 
-  private[phalange] def node2[V, A](a: A, b: A)(implicit measured: Measured[A, V]): Node[V, A] =
-    Node.Node2(measured.append(measured.apply(a), measured.apply(b)), a, b)
-
-  private[phalange] def node3[V, A](a: A, b: A, c: A)(implicit measured: Measured[A, V]): Node[V, A] =
-    Node.Node3(measured.append(measured.append(measured.apply(a), measured.apply(b)), measured.apply(c)), a, b, c)
+  private[phalange] def apply[V, A](a: A, b: A, c: A)(implicit measured: Measured[A, V]): Node[V, A] =
+    new Node[V, A] {
+      def fold[B](node2: (Lazy[V], A, A) => B, node3: (Lazy[V], A, A, A) => B): B =
+        node3(
+          new Lazy(measured.append(measured.apply(a), measured.append(measured.apply(b), measured.apply(c)))),
+          a,
+          b,
+          c
+        )
+    }
 }

--- a/src/main/scala/net/jcazevedo/phalange/Node.scala
+++ b/src/main/scala/net/jcazevedo/phalange/Node.scala
@@ -1,6 +1,6 @@
 package net.jcazevedo.phalange
 
-private[phalange] sealed abstract class Node[V, +A] extends Iterable[A] {
+private[phalange] sealed abstract class Node[V, A] extends Iterable[A] {
   private[phalange] def fold[B](node2: (Lazy[V], A, A) => B, node3: (Lazy[V], A, A, A) => B): B
 
   final def measure: V =

--- a/src/main/scala/net/jcazevedo/phalange/Node.scala
+++ b/src/main/scala/net/jcazevedo/phalange/Node.scala
@@ -1,6 +1,6 @@
 package net.jcazevedo.phalange
 
-private[phalange] sealed abstract class Node[V, A] extends Iterable[A] {
+private[phalange] sealed abstract class Node[V, A](implicit measured: Measured[A, V]) extends Iterable[A] {
   private[phalange] def fold[B](node2: (Lazy[V], A, A) => B, node3: (Lazy[V], A, A, A) => B): B
 
   final def measure: V =
@@ -8,6 +8,9 @@ private[phalange] sealed abstract class Node[V, A] extends Iterable[A] {
 
   final def iterator: Iterator[A] =
     fold(node2 = (_, a, b) => Iterator(a, b), node3 = (_, a, b, c) => Iterator(a, b, c))
+
+  final def toDigit: Digit[V, A] =
+    fold(node2 = (_, a, b) => Digit(a, b), node3 = (_, a, b, c) => Digit(a, b, c))
 }
 
 private[phalange] object Node {

--- a/src/main/scala/net/jcazevedo/phalange/Node.scala
+++ b/src/main/scala/net/jcazevedo/phalange/Node.scala
@@ -1,14 +1,23 @@
 package net.jcazevedo.phalange
 
-private[phalange] sealed trait Node[+A] extends Iterable[A] {
+private[phalange] sealed trait Node[V, +A] extends Iterable[A] {
   def iterator: Iterator[A] =
     this match {
-      case Node.Node2(a, b)    => Iterator(a, b)
-      case Node.Node3(a, b, c) => Iterator(a, b, c)
+      case Node.Node2(_, a, b)    => Iterator(a, b)
+      case Node.Node3(_, a, b, c) => Iterator(a, b, c)
     }
 }
 
 private[phalange] object Node {
-  private[phalange] case class Node2[+A](a: A, b: A) extends Node[A]
-  private[phalange] case class Node3[+A](a: A, b: A, c: A) extends Node[A]
+  private[phalange] case class Node2[V, +A](v: V, a: A, b: A) extends Node[V, A]
+  private[phalange] case class Node3[V, +A](v: V, a: A, b: A, c: A) extends Node[V, A]
+
+  private[phalange] def node2[V, A](a: A, b: A)(implicit measured: Measured[A, V], monoid: Monoid[V]): Node[V, A] =
+    Node.Node2(monoid.append(measured.apply(a), measured.apply(b)), a, b)
+
+  private[phalange] def node3[V, A](a: A, b: A, c: A)(implicit
+      measured: Measured[A, V],
+      monoid: Monoid[V]
+  ): Node[V, A] =
+    Node.Node3(monoid.append(monoid.append(measured.apply(a), measured.apply(b)), measured.apply(c)), a, b, c)
 }

--- a/src/main/scala/net/jcazevedo/phalange/ViewL.scala
+++ b/src/main/scala/net/jcazevedo/phalange/ViewL.scala
@@ -1,8 +1,19 @@
 package net.jcazevedo.phalange
 
-private[phalange] sealed trait ViewL[V, A]
+private[phalange] sealed abstract class ViewL[V, A] {
+  private[phalange] def fold[B](empty: => B, cons: (A, Lazy[FingerTree[V, A]]) => B): B
+}
 
 private[phalange] object ViewL {
-  private[phalange] case class Empty[V, A]() extends ViewL[V, A]
-  private[phalange] case class Cons[V, A](head: A, tail: Lazy[FingerTree[V, A]]) extends ViewL[V, A]
+  private[phalange] def empty[V, A]: ViewL[V, A] =
+    new ViewL[V, A] {
+      def fold[B](empty: => B, cons: (A, Lazy[FingerTree[V, A]]) => B): B =
+        empty
+    }
+
+  private[phalange] def cons[V, A](head: A, tail: Lazy[FingerTree[V, A]]): ViewL[V, A] =
+    new ViewL[V, A] {
+      def fold[B](empty: => B, cons: (A, Lazy[FingerTree[V, A]]) => B): B =
+        cons(head, tail)
+    }
 }

--- a/src/main/scala/net/jcazevedo/phalange/ViewL.scala
+++ b/src/main/scala/net/jcazevedo/phalange/ViewL.scala
@@ -1,8 +1,8 @@
 package net.jcazevedo.phalange
 
-private[phalange] sealed trait ViewL[V, +A]
+private[phalange] sealed trait ViewL[V, A]
 
 private[phalange] object ViewL {
-  private[phalange] case class Empty[V]() extends ViewL[V, Nothing]
-  private[phalange] case class Cons[V, +A](head: A, tail: Lazy[FingerTree[V, A]]) extends ViewL[V, A]
+  private[phalange] case class Empty[V, A]() extends ViewL[V, A]
+  private[phalange] case class Cons[V, A](head: A, tail: Lazy[FingerTree[V, A]]) extends ViewL[V, A]
 }

--- a/src/main/scala/net/jcazevedo/phalange/ViewL.scala
+++ b/src/main/scala/net/jcazevedo/phalange/ViewL.scala
@@ -1,8 +1,8 @@
 package net.jcazevedo.phalange
 
-private[phalange] sealed trait ViewL[+A]
+private[phalange] sealed trait ViewL[V, +A]
 
 private[phalange] object ViewL {
-  private[phalange] case object Empty extends ViewL[Nothing]
-  private[phalange] case class Cons[+A](head: A, tail: Lazy[FingerTree[A]]) extends ViewL[A]
+  private[phalange] case class Empty[V]() extends ViewL[V, Nothing]
+  private[phalange] case class Cons[V, +A](head: A, tail: Lazy[FingerTree[V, A]]) extends ViewL[V, A]
 }

--- a/src/main/scala/net/jcazevedo/phalange/ViewR.scala
+++ b/src/main/scala/net/jcazevedo/phalange/ViewR.scala
@@ -1,8 +1,8 @@
 package net.jcazevedo.phalange
 
-private[phalange] sealed trait ViewR[+A]
+private[phalange] sealed trait ViewR[V, +A]
 
 private[phalange] object ViewR {
-  private[phalange] case object Empty extends ViewR[Nothing]
-  private[phalange] case class Cons[+A](tail: Lazy[FingerTree[A]], head: A) extends ViewR[A]
+  private[phalange] case class Empty[V]() extends ViewR[V, Nothing]
+  private[phalange] case class Cons[V, +A](tail: Lazy[FingerTree[V, A]], head: A) extends ViewR[V, A]
 }

--- a/src/main/scala/net/jcazevedo/phalange/ViewR.scala
+++ b/src/main/scala/net/jcazevedo/phalange/ViewR.scala
@@ -1,8 +1,8 @@
 package net.jcazevedo.phalange
 
-private[phalange] sealed trait ViewR[V, +A]
+private[phalange] sealed trait ViewR[V, A]
 
 private[phalange] object ViewR {
-  private[phalange] case class Empty[V]() extends ViewR[V, Nothing]
-  private[phalange] case class Cons[V, +A](tail: Lazy[FingerTree[V, A]], head: A) extends ViewR[V, A]
+  private[phalange] case class Empty[V, A]() extends ViewR[V, A]
+  private[phalange] case class Cons[V, A](tail: Lazy[FingerTree[V, A]], head: A) extends ViewR[V, A]
 }

--- a/src/main/scala/net/jcazevedo/phalange/ViewR.scala
+++ b/src/main/scala/net/jcazevedo/phalange/ViewR.scala
@@ -1,8 +1,19 @@
 package net.jcazevedo.phalange
 
-private[phalange] sealed trait ViewR[V, A]
+private[phalange] sealed abstract class ViewR[V, A] {
+  private[phalange] def fold[B](empty: => B, cons: (Lazy[FingerTree[V, A]], A) => B): B
+}
 
 private[phalange] object ViewR {
-  private[phalange] case class Empty[V, A]() extends ViewR[V, A]
-  private[phalange] case class Cons[V, A](tail: Lazy[FingerTree[V, A]], head: A) extends ViewR[V, A]
+  private[phalange] def empty[V, A]: ViewR[V, A] =
+    new ViewR[V, A] {
+      def fold[B](empty: => B, cons: (Lazy[FingerTree[V, A]], A) => B): B =
+        empty
+    }
+
+  private[phalange] def cons[V, A](tail: Lazy[FingerTree[V, A]], head: A): ViewR[V, A] =
+    new ViewR[V, A] {
+      def fold[B](empty: => B, cons: (Lazy[FingerTree[V, A]], A) => B): B =
+        cons(tail, head)
+    }
 }

--- a/src/test/scala/net/jcazevedo/phalange/FingerTreeSpec.scala
+++ b/src/test/scala/net/jcazevedo/phalange/FingerTreeSpec.scala
@@ -40,7 +40,7 @@ class FingerTreeSpec extends Specification with ScalaCheck {
     }
 
     "support isEmpty and nonEmpty operations in empty trees" in {
-      val ft = FingerTree.empty[Unit, Int]
+      val ft = FingerTree.apply[Int]()
       ft.isEmpty ==== true
       ft.nonEmpty ==== false
     }
@@ -53,7 +53,7 @@ class FingerTreeSpec extends Specification with ScalaCheck {
     }
 
     "support a headL operation in empty trees" in {
-      val ft = FingerTree.empty[Unit, Int]
+      val ft = FingerTree.apply[Int]()
       ft.headL must throwA[NoSuchElementException]
     }
 
@@ -65,7 +65,7 @@ class FingerTreeSpec extends Specification with ScalaCheck {
     }
 
     "support a headLOption operation in empty trees" in {
-      val ft = FingerTree.empty[Unit, Int]
+      val ft = FingerTree.apply[Int]()
       ft.headLOption ==== None
     }
 
@@ -77,7 +77,7 @@ class FingerTreeSpec extends Specification with ScalaCheck {
     }
 
     "support a tailL operation in empty trees" in {
-      val ft = FingerTree.empty[Unit, Int]
+      val ft = FingerTree.apply[Int]()
       ft.tailL must throwA[NoSuchElementException]
     }
 
@@ -89,7 +89,7 @@ class FingerTreeSpec extends Specification with ScalaCheck {
     }
 
     "support a tailLOption operation in empty trees" in {
-      val ft = FingerTree.empty[Unit, Int]
+      val ft = FingerTree.apply[Int]()
       ft.tailLOption ==== None
     }
 
@@ -101,7 +101,7 @@ class FingerTreeSpec extends Specification with ScalaCheck {
     }
 
     "support a headR operation in empty trees" in {
-      val ft = FingerTree.empty[Unit, Int]
+      val ft = FingerTree.apply[Int]()
       ft.headR must throwA[NoSuchElementException]
     }
 
@@ -113,7 +113,7 @@ class FingerTreeSpec extends Specification with ScalaCheck {
     }
 
     "support a headROption operation in empty trees" in {
-      val ft = FingerTree.empty[Unit, Int]
+      val ft = FingerTree.apply[Int]()
       ft.headROption ==== None
     }
 
@@ -125,7 +125,7 @@ class FingerTreeSpec extends Specification with ScalaCheck {
     }
 
     "support a tailR operation in empty trees" in {
-      val ft = FingerTree.empty[Unit, Int]
+      val ft = FingerTree.apply[Int]()
       ft.tailR must throwA[NoSuchElementException]
     }
 
@@ -137,7 +137,7 @@ class FingerTreeSpec extends Specification with ScalaCheck {
     }
 
     "support a tailROption operation in empty trees" in {
-      val ft = FingerTree.empty[Unit, Int]
+      val ft = FingerTree.apply[Int]()
       ft.tailROption ==== None
     }
 

--- a/src/test/scala/net/jcazevedo/phalange/FingerTreeSpec.scala
+++ b/src/test/scala/net/jcazevedo/phalange/FingerTreeSpec.scala
@@ -5,6 +5,17 @@ import org.specs2.ScalaCheck
 import org.specs2.mutable.Specification
 
 class FingerTreeSpec extends Specification with ScalaCheck {
+  implicit val unitMeasured: Measured[Any, Unit] =
+    new Measured[Any, Unit] {
+      def apply(a: Any): Unit = ()
+    }
+
+  implicit val unitMonoid: Monoid[Unit] =
+    new Monoid[Unit] {
+      def empty: Unit = ()
+      def append(a: Unit, b: Unit) = ()
+    }
+
   "A FingerTree" should {
     "support an apply method" in forAll { ints: List[Int] =>
       val ft = FingerTree.apply(ints: _*)
@@ -40,7 +51,7 @@ class FingerTreeSpec extends Specification with ScalaCheck {
     }
 
     "support isEmpty and nonEmpty operations in empty trees" in {
-      val ft = FingerTree.empty[Int]
+      val ft = FingerTree.empty[Unit, Int]
       ft.isEmpty ==== true
       ft.nonEmpty ==== false
     }
@@ -53,7 +64,7 @@ class FingerTreeSpec extends Specification with ScalaCheck {
     }
 
     "support a headL operation in empty trees" in {
-      val ft = FingerTree.empty[Int]
+      val ft = FingerTree.empty[Unit, Int]
       ft.headL must throwA[NoSuchElementException]
     }
 
@@ -65,7 +76,7 @@ class FingerTreeSpec extends Specification with ScalaCheck {
     }
 
     "support a headLOption operation in empty trees" in {
-      val ft = FingerTree.empty[Int]
+      val ft = FingerTree.empty[Unit, Int]
       ft.headLOption ==== None
     }
 
@@ -77,7 +88,7 @@ class FingerTreeSpec extends Specification with ScalaCheck {
     }
 
     "support a tailL operation in empty trees" in {
-      val ft = FingerTree.empty[Int]
+      val ft = FingerTree.empty[Unit, Int]
       ft.tailL must throwA[NoSuchElementException]
     }
 
@@ -89,7 +100,7 @@ class FingerTreeSpec extends Specification with ScalaCheck {
     }
 
     "support a tailLOption operation in empty trees" in {
-      val ft = FingerTree.empty[Int]
+      val ft = FingerTree.empty[Unit, Int]
       ft.tailLOption ==== None
     }
 
@@ -101,7 +112,7 @@ class FingerTreeSpec extends Specification with ScalaCheck {
     }
 
     "support a headR operation in empty trees" in {
-      val ft = FingerTree.empty[Int]
+      val ft = FingerTree.empty[Unit, Int]
       ft.headR must throwA[NoSuchElementException]
     }
 
@@ -113,7 +124,7 @@ class FingerTreeSpec extends Specification with ScalaCheck {
     }
 
     "support a headROption operation in empty trees" in {
-      val ft = FingerTree.empty[Int]
+      val ft = FingerTree.empty[Unit, Int]
       ft.headROption ==== None
     }
 
@@ -125,7 +136,7 @@ class FingerTreeSpec extends Specification with ScalaCheck {
     }
 
     "support a tailR operation in empty trees" in {
-      val ft = FingerTree.empty[Int]
+      val ft = FingerTree.empty[Unit, Int]
       ft.tailR must throwA[NoSuchElementException]
     }
 
@@ -137,7 +148,7 @@ class FingerTreeSpec extends Specification with ScalaCheck {
     }
 
     "support a tailROption operation in empty trees" in {
-      val ft = FingerTree.empty[Int]
+      val ft = FingerTree.empty[Unit, Int]
       ft.tailROption ==== None
     }
 

--- a/src/test/scala/net/jcazevedo/phalange/FingerTreeSpec.scala
+++ b/src/test/scala/net/jcazevedo/phalange/FingerTreeSpec.scala
@@ -8,10 +8,6 @@ class FingerTreeSpec extends Specification with ScalaCheck {
   implicit val unitMeasured: Measured[Any, Unit] =
     new Measured[Any, Unit] {
       def apply(a: Any): Unit = ()
-    }
-
-  implicit val unitMonoid: Monoid[Unit] =
-    new Monoid[Unit] {
       def empty: Unit = ()
       def append(a: Unit, b: Unit) = ()
     }

--- a/src/test/scala/net/jcazevedo/phalange/FingerTreeSpec.scala
+++ b/src/test/scala/net/jcazevedo/phalange/FingerTreeSpec.scala
@@ -160,5 +160,18 @@ class FingerTreeSpec extends Specification with ScalaCheck {
       resultFt.foldRight(List.empty[Int])(_ :: _) ==== resultList
       resultFt.foldLeft(0L)(_ + _.toLong) ==== resultList.map(_.toLong).sum
     }
+
+    "support implementing random access sequences" in {
+      implicit val sizeMeasured: Measured[Int, Int] =
+        new Measured[Int, Int] {
+          def apply(v: Int): Int = 1
+          def empty: Int = 0
+          def append(a: Int, b: Int): Int = a + b
+        }
+      forall(0 to 100) { length =>
+        val ft = FingerTree.measured((1 to length): _*)
+        forall((0 to length))(len => ft.takeUntil(_ > len).toList ==== (1 to len).toList)
+      }
+    }
   }
 }

--- a/src/test/scala/net/jcazevedo/phalange/FingerTreeSpec.scala
+++ b/src/test/scala/net/jcazevedo/phalange/FingerTreeSpec.scala
@@ -5,13 +5,6 @@ import org.specs2.ScalaCheck
 import org.specs2.mutable.Specification
 
 class FingerTreeSpec extends Specification with ScalaCheck {
-  implicit val unitMeasured: Measured[Any, Unit] =
-    new Measured[Any, Unit] {
-      def apply(a: Any): Unit = ()
-      def empty: Unit = ()
-      def append(a: Unit, b: Unit) = ()
-    }
-
   "A FingerTree" should {
     "support an apply method" in forAll { ints: List[Int] =>
       val ft = FingerTree.apply(ints: _*)


### PR DESCRIPTION
This adds initial support for annotated sequences. This is still a work in progress, lacking the split method which should enable some more interesting use cases.